### PR TITLE
Fix for importing lib in red

### DIFF
--- a/Mainframe3270/x3270.py
+++ b/Mainframe3270/x3270.py
@@ -29,7 +29,7 @@ class x3270(object):
             if "Cannot access execution context" in str(rnrex):
                 self.output_folder = os.getcwd()
             else:
-                raise RobotNotRunningError
+                raise RobotNotRunningError()
         except Exception as e:
             raise AssertionError(e)
         self.wait = float(wait_time)

--- a/Mainframe3270/x3270.py
+++ b/Mainframe3270/x3270.py
@@ -6,6 +6,7 @@ import re
 from .py3270 import Emulator
 from robot.api import logger
 from robot.libraries.BuiltIn import BuiltIn
+from robot.libraries.BuiltIn import RobotNotRunningError
 from robot.utils import Matcher
 
 
@@ -23,10 +24,14 @@ class x3270(object):
         self.imgfolder = img_folder
         # Try Catch to run in Pycharm, and make a documentation in libdoc with no error
         try:
-            self.output_folder = BuiltIn().get_variable_value('${OUTPUT DIR}')
+            self.output_folder = BuiltIn().get_variable_value('${OUTPUT_DIR}')
+        except RobotNotRunningError as rnrex:
+            if "Cannot access execution context" in str(rnrex):
+                self.output_folder = os.getcwd()
+            else:
+                raise RobotNotRunningError
         except Exception as e:
-            if hasattr(e, 'message') and e.message == 'Cannot access execution context': self.output_folder = os.getcwd()
-            else: raise AssertionError(e)
+            raise AssertionError(e)
         self.wait = float(wait_time)
         self.wait_write = float(wait_time_after_write)
         self.timeout = int(timeout)

--- a/Mainframe3270/x3270.py
+++ b/Mainframe3270/x3270.py
@@ -24,7 +24,7 @@ class x3270(object):
         self.imgfolder = img_folder
         # Try Catch to run in Pycharm, and make a documentation in libdoc with no error
         try:
-            self.output_folder = BuiltIn().get_variable_value('${OUTPUT_DIR}')
+            self.output_folder = BuiltIn().get_variable_value('${OUTPUT DIR}')
         except RobotNotRunningError as rnrex:
             if "Cannot access execution context" in str(rnrex):
                 self.output_folder = os.getcwd()


### PR DESCRIPTION
Fix for #9 
I was also unable to import lib correclty to RED editor. So i've done some analysis and it appears, that root exception (RobotNotRunningError) has no attribute "message" so it can't handle correctly this try/except clasue.