### PR TITLE
create read all screen keyword

### DIFF
--- a/Mainframe3270/x3270.py
+++ b/Mainframe3270/x3270.py
@@ -165,6 +165,11 @@ class x3270(object):
         string = self.mf.string_get(int(ypos), int(xpos), int(length))
         return str(string)
 
+    def read_all_screen(self):
+        """Reads the current screen and returns content in one string.
+        """
+        return self._read_all_screen()
+
     def execute_command(self, cmd):
         """Execute an [http://x3270.bgp.nu/wc3270-man.html#Actions|x3270 command].
 

--- a/tests/mainframe.robot
+++ b/tests/mainframe.robot
@@ -45,6 +45,7 @@ Test Without Login
     Test Page Should Not Contain Match
     Test Page Should Not Contain String
     Test Read
+    Test Read All Screen
     Test Write Bare
     Test Write Bare In Position
     Test Delete Char
@@ -123,6 +124,12 @@ Test Page Should Not Contain String
 Test Read
     ${read_text}    Read    1    10    48
     Should Be Equal As Strings    ${welcome_title}    ${read_text}
+
+Test Read All Screen
+    ${screen_content}   Read All Screen
+    Should Contain    ${screen_content}    i
+    Should Contain    ${screen_content}    c I
+    Should Not Contain    ${screen_content}    xyz
 
 Test Write Bare
     Write Bare    ${write_text}


### PR DESCRIPTION
Hi there,

I am currently working on a project where we have keywords that take different paths if a certain text is displayed on the screen or not. 

Until now, I have been working with the Read Keyword in this situation, as in:

```
${msg}    Read    ypos=1    xpos=1     length=10
${condition}    Evaluate    "text" in """${msg}"""
IF    ${condition}==True
    Do Something
Else
    Do Something Else
End
```

While this is working so far, I see a problem, since this is approach is highly dependent on the string's exact x and y position. If, for instance, a change is made to the UI and the string is now on ypos+1, the condition will be false.

This is why I created a keyword that does not care for the message's exact position, but focuses only on whether the message is contained in the current screen or not.

I would be very happy if you could incorporate these changes. In case there is any criticism, please feel free to reach out. 