### PR TITLE
Create changelog

### DIFF
--- a/.github/workflows/generate-changelog.yml
+++ b/.github/workflows/generate-changelog.yml
@@ -1,0 +1,17 @@
+name: Changelog CI
+
+on:
+  pull_request:
+    types: [ opened ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Run Changelog CI
+        uses: saadmk11/changelog-ci@v1.0.0
+        with:
+          config_file: changelog-ci-config.yaml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Version: 2.12
+
+* [#43](https://github.com/Altran-PT-GDC/Robot-Framework-Mainframe-3270-Library/pull/43): Enable run on failure keyword
+
+
+# Version: 2.11
+
+* [#33](https://github.com/Altran-PT-GDC/Robot-Framework-Mainframe-3270-Library/pull/33): create read all screen keyword

--- a/changelog-ci-config.yaml
+++ b/changelog-ci-config.yaml
@@ -1,0 +1,25 @@
+changelog_type: 'pull_request'
+header_prefix: 'Version:'
+commit_changelog: true
+comment_changelog: true
+include_unlabeled_changes: true
+unlabeled_group_title: 'Unlabeled Changes'
+pull_request_title_regex: '(^.*[0-9]{1,2}[.]+[0-9]{1,2})'
+version_regex: '([0-9]{1,2}[.]+[0-9]{1,2})'
+group_config:
+  - title: Bug Fixes
+    labels:
+      - bug
+      - bugfix
+  - title: Code Improvements
+    labels:
+      - improvements
+      - enhancement
+  - title: New Features
+    labels:
+      - feature
+  - title: Documentation Updates
+    labels:
+      - docs
+      - documentation
+      - doc


### PR DESCRIPTION
Hi there,

this is a proposal for [issue #46](https://github.com/Altran-PT-GDC/Robot-Framework-Mainframe-3270-Library/issues/46).

This PR contains 2 changes:

- First, I added a changelog, which as of now contains Versions 2.11 and 2.12.

- Second, I set up changelog-ci.

For this, two additional files where created:
- `.github/workflows/generate-changelog.yml`. This will run on opened pull requests.
- `changelog-ci-config.yaml`. The options in this file are explained in detail [here](https://github.com/marketplace/actions/changelog-ci#configuration-file-options).


Basically, how changelog-ci works is that it uses github api to include PR titles between releases in the changelog. Not all PRs will provoke the generation. Only if the title matches the regex specified under `pull_request_title_regex` in the config file.


Here is an example, of how the workflow will look like:
- PR 1: New feature a
- PR 2: Release 2.12 --> matches regex, so changelog will be generated
- **GitHub Release 2.12**
- PR 3: New feature b
- PR 4: New feature c
- PR 5: Release 2.13 --> matches regex, so changelog will be generated
- **GitHub Release 2.13**


Changelog will look like this
# Version 2.13:

* [#4](linktopr): New feature c
* [#3](linktopr): New feature b

# Version 2.12:
* [#1](linktopr): New feature a
* 
....


#### Implication to the current workflow
From what I have seen, the only change to the current workflow is that we need to create a release after the PR with new release is merged.



  
