### PR TITLE
Add third party notices

### DIFF
--- a/THIRD-PARTY-NOTICES.txt
+++ b/THIRD-PARTY-NOTICES.txt
@@ -1,0 +1,37 @@
+Robot-Framework-Mainframe3270-Library uses third-party libraries or other resources that may be
+distributed under licenses different than the Robot-Framework-Mainframe3270-Library software.
+
+In the event that we accidentally failed to list a required notice, please
+bring it to our attention by posting an issue or making a pull request to our
+GitHub repository:
+
+https://github.com/Altran-PT-GDC/Robot-Framework-Mainframe-3270-Library/
+
+The attached notices are provided for information only.
+
+License notice for py3270
+-------------------------
+Copyright (c) 2018, Randy Syring and contributors
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of the <organization> nor the
+      names of its contributors may be used to endorse or promote products
+      derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL <COPYRIGHT HOLDER> BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ package_kwargs = {
     "author": "Altran Portugal",
     "author_email": "samuel.cabral@altran.com",
     "license": "MIT License",
+    "license_files": ["LICENSE.md", "THIRD-PARTY-NOTICES.txt"],
     "url": "https://github.com/Altran-PT-GDC/Robot-Framework-Mainframe-3270-Library",
     "packages": ["Mainframe3270"],
     "install_requires": ["robotframework", "robotframework-pythonlibcore", "six"],


### PR DESCRIPTION
Since we are using a derivative version of py3270, I though it is only fair to include their license text and notice to this repository.