### PR TITLE
Adjust CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,30 +1,8 @@
 # Version: 3.0
 
-
-#### Unlabeled Changes
-
-* [#3](https://github.com/Altran-PT-GDC/Robot-Framework-Mainframe-3270-Library/pull/3): Fix wait until string
-* [#2](https://github.com/Altran-PT-GDC/Robot-Framework-Mainframe-3270-Library/pull/2): Update keyword tests
-* [#8](https://github.com/Altran-PT-GDC/Robot-Framework-Mainframe-3270-Library/pull/8): Log improvement
-* [#1](https://github.com/Altran-PT-GDC/Robot-Framework-Mainframe-3270-Library/pull/1): Handling exceptions
-* [#6](https://github.com/Altran-PT-GDC/Robot-Framework-Mainframe-3270-Library/pull/6): Docker container
-* [#10](https://github.com/Altran-PT-GDC/Robot-Framework-Mainframe-3270-Library/pull/10): Change wait time after write
-* [#7](https://github.com/Altran-PT-GDC/Robot-Framework-Mainframe-3270-Library/pull/7): Hi fi docker container
-* [#13](https://github.com/Altran-PT-GDC/Robot-Framework-Mainframe-3270-Library/pull/13): pip Install
-* [#15](https://github.com/Altran-PT-GDC/Robot-Framework-Mainframe-3270-Library/pull/15): Version2.8
-* [#16](https://github.com/Altran-PT-GDC/Robot-Framework-Mainframe-3270-Library/pull/16): Fix for importing lib in red
-* [#18](https://github.com/Altran-PT-GDC/Robot-Framework-Mainframe-3270-Library/pull/18): Enable re-open within single .robot file
-* [#22](https://github.com/Altran-PT-GDC/Robot-Framework-Mainframe-3270-Library/pull/22): Open Connection to the correct port
-* [#33](https://github.com/Altran-PT-GDC/Robot-Framework-Mainframe-3270-Library/pull/33): create read all screen keyword
-* [#29](https://github.com/Altran-PT-GDC/Robot-Framework-Mainframe-3270-Library/pull/29): new version 2.9
-* [#40](https://github.com/Altran-PT-GDC/Robot-Framework-Mainframe-3270-Library/pull/40): 2.11
-* [#30](https://github.com/Altran-PT-GDC/Robot-Framework-Mainframe-3270-Library/pull/30): V2.10
-* [#44](https://github.com/Altran-PT-GDC/Robot-Framework-Mainframe-3270-Library/pull/44): 2.12
-* [#43](https://github.com/Altran-PT-GDC/Robot-Framework-Mainframe-3270-Library/pull/43): Enable run on failure keyword
 * [#45](https://github.com/Altran-PT-GDC/Robot-Framework-Mainframe-3270-Library/pull/45): Update README.md
 * [#48](https://github.com/Altran-PT-GDC/Robot-Framework-Mainframe-3270-Library/pull/48): Setup continuous integration
 * [#50](https://github.com/Altran-PT-GDC/Robot-Framework-Mainframe-3270-Library/pull/50): Code Formatting (#49)
-* [#47](https://github.com/Altran-PT-GDC/Robot-Framework-Mainframe-3270-Library/pull/47): Create changelog
 * [#52](https://github.com/Altran-PT-GDC/Robot-Framework-Mainframe-3270-Library/pull/52): Read extra arguments from list or file
 * [#55](https://github.com/Altran-PT-GDC/Robot-Framework-Mainframe-3270-Library/pull/55): Drop Python2 Support
 * [#56](https://github.com/Altran-PT-GDC/Robot-Framework-Mainframe-3270-Library/pull/56): Add type hints to library (#53)

--- a/changelog-ci-config.yaml
+++ b/changelog-ci-config.yaml
@@ -3,23 +3,5 @@ header_prefix: 'Version:'
 commit_changelog: true
 comment_changelog: true
 include_unlabeled_changes: true
-unlabeled_group_title: 'Unlabeled Changes'
 pull_request_title_regex: '(^.*[0-9]{1,2}[.]+[0-9]{1,2})'
 version_regex: '([0-9]{1,2}[.]+[0-9]{1,2})'
-group_config:
-  - title: Bug Fixes
-    labels:
-      - bug
-      - bugfix
-  - title: Code Improvements
-    labels:
-      - improvements
-      - enhancement
-  - title: New Features
-    labels:
-      - feature
-  - title: Documentation Updates
-    labels:
-      - docs
-      - documentation
-      - doc


### PR DESCRIPTION
I corrected some entries in the changelog.

To avoid these manual fixes, we should create releases for this project. Ideally before merging this PR.

To create a new release, you
- go to https://github.com/Altran-PT-GDC/Robot-Framework-Mainframe-3270-Library/releases/new
- click the "Choose a tag" dropdown and provide a new release tag, e.g. 3.0 for the most recent release
![grafik](https://user-images.githubusercontent.com/76647407/160689945-9c0b5f30-0231-4660-8b0b-0a36799c6f52.png)

- Optionally, provide a title and a description for the releases
- Click the "Publish Release button" on the bottom of the page
![grafik](https://user-images.githubusercontent.com/76647407/160690282-edda9db2-bf58-4245-876b-afad52d0ebb3.png)

- Done 