### PR TITLE
(#31) Setup the emulator model

### DIFF
--- a/Mainframe3270/__init__.py
+++ b/Mainframe3270/__init__.py
@@ -8,9 +8,14 @@ from robot.libraries.BuiltIn import BuiltIn, RobotNotRunningError
 from robot.utils import ConnectionCache
 from robotlibcore import DynamicCore
 
-from Mainframe3270.keywords import (AssertionKeywords, CommandKeywords,
-                                    ConnectionKeywords, ReadWriteKeywords,
-                                    ScreenshotKeywords, WaitAndTimeoutKeywords)
+from Mainframe3270.keywords import (
+    AssertionKeywords,
+    CommandKeywords,
+    ConnectionKeywords,
+    ReadWriteKeywords,
+    ScreenshotKeywords,
+    WaitAndTimeoutKeywords,
+)
 from Mainframe3270.py3270 import Emulator
 from Mainframe3270.utils import convert_timeout
 from Mainframe3270.version import VERSION
@@ -159,8 +164,6 @@ class Mainframe3270(DynamicCore):
             self._running_on_failure_keyword = True
             BuiltIn().run_keyword(self.run_on_failure_keyword)
         except Exception as error:
-            logger.warn(
-                f"Keyword '{self.run_on_failure_keyword}' could not be run on failure: {error}"
-            )
+            logger.warn(f"Keyword '{self.run_on_failure_keyword}' could not be run on failure: {error}")
         finally:
             self._running_on_failure_keyword = False

--- a/Mainframe3270/__init__.py
+++ b/Mainframe3270/__init__.py
@@ -73,6 +73,46 @@ class Mainframe3270(DynamicCore):
     |     Switch Connection    second    # switchting the ocnnection using the alias
     |     Page Should Contain String    Second String
     |     [Teardown]    Close All Connections
+
+    = Changing the emulator model (experimental) =
+
+    By default, the library uses the emulator model 2, which is 24 rows by 80 columns.
+    You can, however, change the model globally when `importing` the library with the `model` argument
+    set to the model of your choice.
+
+    The basic models are 2, 3, 4, and 5. These models differ in their screen size as illustrated in this table:
+
+    | *3270 Model* | *Rows* | *Columns* |
+    | 2            | 24     | 80        |
+    | 3            | 32     | 80        |
+    | 4            | 43     | 80        |
+    | 5            | 27     | 132       |
+
+
+    They can be combined with the 3278 (monochrome green-screen) or 3279 (color) prefix, e.g. 3278-2 or 3279-2.
+
+    In addition to that, there is a -E suffix that indicates support for the [https://x3270.miraheze.org/wiki/3270_data_stream_protocol#extended|x3270 extended data stream].
+
+    You can find more information on emulator models on the [https://x3270.miraheze.org/wiki/3270_models|x3270 wiki].
+
+    In addition to setting the model globally, you can also set the model on the individual emulator basis by providing the model arguments to the `Open Connection`
+    or `Open Connection From Session File` keywords.
+
+    Here is an example for setting the emulator in the Open Connection keyword:
+
+    | Open Connection    pub400.com    extra_args=["-xrm", "*model: 4"]
+
+    And this is how you would set the emulator model in the Open Connection From Session File keyword:
+
+    | Open Connection From Session File    /path/to/session/file
+
+    Where the content of the session file would be
+
+    | *hostname: pub400.com
+    | *model: 4
+
+
+    Note that this is an experimental feature, so not all models might work as expected.
     """
 
     ROBOT_LIBRARY_SCOPE = "TEST SUITE"

--- a/Mainframe3270/__init__.py
+++ b/Mainframe3270/__init__.py
@@ -86,6 +86,7 @@ class Mainframe3270(DynamicCore):
         wait_time_after_write: timedelta = timedelta(seconds=0),
         img_folder: str = ".",
         run_on_failure_keyword: str = "Take Screenshot",
+        model: str = "2",
     ) -> None:
         """
         By default the emulator visibility is set to visible=True.
@@ -112,6 +113,7 @@ class Mainframe3270(DynamicCore):
         self.img_folder = img_folder
         self._running_on_failure_keyword = False
         self.register_run_on_failure_keyword(run_on_failure_keyword)
+        self.model = model
         self.cache = ConnectionCache()
         # When generating the library documentation with libdoc, BuiltIn.get_variable_value throws
         # a RobotNotRunningError. Therefore, we catch it here to be able to generate the documentation.

--- a/Mainframe3270/keywords/__init__.py
+++ b/Mainframe3270/keywords/__init__.py
@@ -3,5 +3,4 @@ from Mainframe3270.keywords.commands import CommandKeywords  # noqa: F401
 from Mainframe3270.keywords.connection import ConnectionKeywords  # noqa: F401
 from Mainframe3270.keywords.read_write import ReadWriteKeywords  # noqa: F401
 from Mainframe3270.keywords.screenshot import ScreenshotKeywords  # noqa: F401
-from Mainframe3270.keywords.wait_and_timeout import \
-    WaitAndTimeoutKeywords  # noqa: F401
+from Mainframe3270.keywords.wait_and_timeout import WaitAndTimeoutKeywords  # noqa: F401

--- a/Mainframe3270/keywords/assertions.py
+++ b/Mainframe3270/keywords/assertions.py
@@ -1,8 +1,10 @@
 import re
 from typing import List, Optional
+
 from robot.api import logger
 from robot.api.deco import keyword
 from robot.utils import Matcher
+
 from Mainframe3270.librarycomponent import LibraryComponent
 
 
@@ -109,9 +111,7 @@ class AssertionKeywords(LibraryComponent):
             | Page Should Not Contain Any Strings | ${list_of_string} | ignore_case=True |
             | Page Should Not Contain Any Strings | ${list_of_string} | error_message=New error message |
         """
-        self._compare_all_list_with_screen_text(
-            list_string, ignore_case, error_message, should_match=False
-        )
+        self._compare_all_list_with_screen_text(list_string, ignore_case, error_message, should_match=False)
 
     @keyword("Page Should Contain All Strings")
     def page_should_contain_all_strings(
@@ -132,9 +132,7 @@ class AssertionKeywords(LibraryComponent):
             | Page Should Contain All Strings | ${list_of_string} | ignore_case=True |
             | Page Should Contain All Strings | ${list_of_string} | error_message=New error message |
         """
-        self._compare_all_list_with_screen_text(
-            list_string, ignore_case, error_message, should_match=True
-        )
+        self._compare_all_list_with_screen_text(list_string, ignore_case, error_message, should_match=True)
 
     @keyword("Page Should Not Contain All Strings")
     def page_should_not_contain_all_strings(

--- a/Mainframe3270/keywords/commands.py
+++ b/Mainframe3270/keywords/commands.py
@@ -1,6 +1,8 @@
 import time
 from typing import Optional
+
 from robot.api.deco import keyword
+
 from Mainframe3270.librarycomponent import LibraryComponent
 
 

--- a/Mainframe3270/keywords/connection.py
+++ b/Mainframe3270/keywords/connection.py
@@ -146,12 +146,12 @@ class ConnectionKeywords(LibraryComponent):
         """
         self._check_session_file_extension(session_file)
         self._check_contains_hostname(session_file)
-        self._check_model(session_file)
+        model = self._get_model_from_list_or_file(session_file)
         if os_name == "nt" and self.visible:
-            connection = Emulator(self.visible, self.timeout)
+            connection = Emulator(self.visible, self.timeout, model=model or self.model)
             connection.connect(str(session_file))
         else:
-            connection = Emulator(self.visible, self.timeout, [str(session_file)])
+            connection = Emulator(self.visible, self.timeout, [str(session_file)], model or self.model)
         return self.cache.register(connection, alias)
 
     def _check_session_file_extension(self, session_file):
@@ -179,23 +179,6 @@ class ConnectionKeywords(LibraryComponent):
                     "to set up the connection. "
                     "An example for wc3270 looks like this: \n"
                     "wc3270.hostname: myhost.com\n"
-                )
-
-    @staticmethod
-    def _check_model(session_file):
-        with open(session_file) as file:
-            pattern = re.compile(r"[wcxs3270.*]+model:\s*([327892345E-]+)")
-            match = pattern.findall(file.read())
-            if not match:
-                return
-            elif match[-1] == "2":
-                return
-            else:
-                raise ValueError(
-                    f'Robot-Framework-Mainframe-3270-Library currently only supports model "2", '
-                    f'the model you specified in your session file was "{match[-1]}". '
-                    f'Please change it to "2", using either the session wizard if you are on Windows, '
-                    f'or by editing the model resource like this "*model: 2"'
                 )
 
     @keyword("Switch Connection")

--- a/Mainframe3270/keywords/connection.py
+++ b/Mainframe3270/keywords/connection.py
@@ -64,7 +64,8 @@ class ConnectionKeywords(LibraryComponent):
             | Open Connection | Hostname | alias=my_first_connection |
         """
         extra_args = self._process_args(extra_args)
-        connection = Emulator(self.visible, self.timeout, extra_args)
+        model = self._get_model_from_list_or_file(extra_args)
+        connection = Emulator(self.visible, self.timeout, extra_args, model or self.model)
         host_string = f"{LU}@{host}" if LU else host
         if self._port_in_extra_args(extra_args):
             if port != 23:
@@ -94,6 +95,17 @@ class ConnectionKeywords(LibraryComponent):
                     for arg in shlex.split(line):
                         processed_args.append(arg)
         return processed_args
+
+    @staticmethod
+    def _get_model_from_list_or_file(list_or_file):
+        pattern = re.compile(r"[wcxs3270.*]+model:\s*([327892345E-]+)")
+        match = None
+        if isinstance(list_or_file, list):
+            match = pattern.findall(str(list_or_file))
+        elif isinstance(list_or_file, os.PathLike) or isinstance(list_or_file, str):
+            with open(list_or_file) as file:
+                match = pattern.findall(file.read())
+        return None if not match else match[-1]
 
     @staticmethod
     def _port_in_extra_args(args) -> bool:

--- a/Mainframe3270/keywords/connection.py
+++ b/Mainframe3270/keywords/connection.py
@@ -3,8 +3,10 @@ import re
 import shlex
 from os import name as os_name
 from typing import List, Optional, Union
+
 from robot.api import logger
 from robot.api.deco import keyword
+
 from Mainframe3270.librarycomponent import LibraryComponent
 from Mainframe3270.py3270 import Emulator
 
@@ -103,9 +105,7 @@ class ConnectionKeywords(LibraryComponent):
         return False
 
     @keyword("Open Connection From Session File")
-    def open_connection_from_session_file(
-        self, session_file: os.PathLike, alias: Optional[str] = None
-    ) -> int:
+    def open_connection_from_session_file(self, session_file: os.PathLike, alias: Optional[str] = None) -> int:
         """Create a connection to an IBM3270 mainframe
         using a [https://x3270.miraheze.org/wiki/Session_file|session file].
 

--- a/Mainframe3270/keywords/read_write.py
+++ b/Mainframe3270/keywords/read_write.py
@@ -1,6 +1,8 @@
 import time
 from typing import Any, Optional
+
 from robot.api.deco import keyword
+
 from Mainframe3270.librarycomponent import LibraryComponent
 
 

--- a/Mainframe3270/keywords/screenshot.py
+++ b/Mainframe3270/keywords/screenshot.py
@@ -1,7 +1,9 @@
 import os
 import time
+
 from robot.api import logger
 from robot.api.deco import keyword
+
 from Mainframe3270.librarycomponent import LibraryComponent
 
 
@@ -42,13 +44,10 @@ class ScreenshotKeywords(LibraryComponent):
         """
         extension = "html"
         filename_sufix = round(time.time() * 1000)
-        filepath = os.path.join(
-            self.img_folder, "%s_%s.%s" % (filename_prefix, filename_sufix, extension)
-        )
+        filepath = os.path.join(self.img_folder, "%s_%s.%s" % (filename_prefix, filename_sufix, extension))
         self.mf.save_screen(os.path.join(self.output_folder, filepath))
         logger.write(
-            '<iframe src="%s" height="%s" width="%s"></iframe>'
-            % (filepath.replace("\\", "/"), height, width),
+            '<iframe src="%s" height="%s" width="%s"></iframe>' % (filepath.replace("\\", "/"), height, width),
             level="INFO",
             html=True,
         )

--- a/Mainframe3270/keywords/wait_and_timeout.py
+++ b/Mainframe3270/keywords/wait_and_timeout.py
@@ -1,7 +1,9 @@
 import time
 from datetime import timedelta
+
 from robot.api.deco import keyword
 from robot.utils import secs_to_timestr
+
 from Mainframe3270.librarycomponent import LibraryComponent
 from Mainframe3270.utils import convert_timeout
 
@@ -75,9 +77,7 @@ class WaitAndTimeoutKeywords(LibraryComponent):
         self.mf.wait_for_field()
 
     @keyword("Wait Until String")
-    def wait_until_string(
-        self, txt: str, timeout: timedelta = timedelta(seconds=5)
-    ) -> str:
+    def wait_until_string(self, txt: str, timeout: timedelta = timedelta(seconds=5)) -> str:
         """Wait until a string exists on the mainframe screen to perform the next step. If the string does not appear
         in 5 seconds, the keyword will raise an exception. You can define a different timeout.
 

--- a/Mainframe3270/librarycomponent.py
+++ b/Mainframe3270/librarycomponent.py
@@ -1,4 +1,5 @@
 from robot.utils import ConnectionCache
+
 from Mainframe3270.py3270 import Emulator
 
 

--- a/Mainframe3270/librarycomponent.py
+++ b/Mainframe3270/librarycomponent.py
@@ -67,3 +67,7 @@ class LibraryComponent:
     @property
     def output_folder(self):
         return self.library.output_folder
+
+    @property
+    def model(self):
+        return self.library.model

--- a/Mainframe3270/py3270.py
+++ b/Mainframe3270/py3270.py
@@ -8,6 +8,8 @@ from abc import ABC, abstractmethod
 from contextlib import closing
 from os import name as os_name
 
+from robot.utils import seq2str
+
 log = logging.getLogger(__name__)
 """
     Python 3+ note: unicode strings should be used when communicating with the Emulator methods.
@@ -78,9 +80,7 @@ class Command(object):
         if result == "ok":
             return
         if result != "error":
-            raise ValueError(
-                'expected "ok" or "error" result, but received: {0}'.format(result)
-            )
+            raise ValueError('expected "ok" or "error" result, but received: {0}'.format(result))
 
         msg = b"[no error message]"
         if self.data:
@@ -254,7 +254,49 @@ class Emulator(object):
     with it.
     """
 
-    def __init__(self, visible=False, timeout=30, extra_args=None, app=None):
+    _MODEL_TYPES = {
+        "2": "2",
+        "3278-2": "2",
+        "3278-2-E": "2",
+        "3279-2": "2",
+        "3279-2-E": "2",
+        "3": "3",
+        "3278-3": "3",
+        "3278-3-E": "3",
+        "3279-3": "3",
+        "3279-3-E": "3",
+        "4": "4",
+        "3278-4": "4",
+        "3278-4-E": "4",
+        "3279-4": "4",
+        "3279-4-E": "4",
+        "5": "5",
+        "3278-5": "5",
+        "3278-5-E": "5",
+        "3279-5": "5",
+        "3279-5-E": "5",
+    }
+
+    _MODEL_DIMENSIONS = {
+        "2": {
+            "rows": 24,
+            "columns": 80,
+        },
+        "3": {
+            "rows": 32,
+            "columns": 80,
+        },
+        "4": {
+            "rows": 43,
+            "columns": 80,
+        },
+        "5": {
+            "rows": 27,
+            "columns": 132,
+        },
+    }
+
+    def __init__(self, visible=False, timeout=30, extra_args=None, model="2"):
         """
         Create an emulator instance
 
@@ -263,23 +305,26 @@ class Emulator(object):
             to x3270.
         `extra_args` allows sending parameters to the emulator executable
         """
-        self.app = app or self.create_app(visible, extra_args)
+        self.model = model
+        self.model_dimensions = self._set_model_dimensions(model)
+        self.app = self.create_app(visible, extra_args, model)
         self.is_terminated = False
         self.status = Status(None)
         self.timeout = timeout
         self.last_host = None
 
-    def __del__(self):
-        """
-        Since an emulator creates a process (and sometimes a socket handle), it is good practice
-        to clean these up when done. Note, not terminating at this point will usually have no
-        ill effect - only Python 3+ on Windows had problems in this regard.
-        """
-        # self.terminate()     # The terminate function is no longer needed in python 3.8
-        pass
+    def _set_model_dimensions(self, model):
+        try:
+            model_type = Emulator._MODEL_TYPES[model]
+        except KeyError:
+            raise KeyError(
+                f"Model should be one of {seq2str(Emulator._MODEL_TYPES.keys()).replace('and', 'or')}, "
+                f"but was '{model}'."
+            )
+        return Emulator._MODEL_DIMENSIONS[model_type]
 
     @staticmethod
-    def create_app(visible, extra_args):
+    def create_app(visible, extra_args, model):
         if os_name == "nt":
             if visible:
                 return wc3270App(extra_args)
@@ -376,9 +421,7 @@ class Emulator(object):
         self.exec_command("Wait({0}, InputField)".format(self.timeout).encode("utf-8"))
         if self.status.keyboard != b"U":
             raise KeyboardStateError(
-                "keyboard not unlocked, state was: {0}".format(
-                    self.status.keyboard.decode("utf-8")
-                )
+                "keyboard not unlocked, state was: {0}".format(self.status.keyboard.decode("utf-8"))
             )
 
     def move_to(self, ypos, xpos):
@@ -435,16 +478,12 @@ class Emulator(object):
         terminal.
         """
         self._check_limits(ypos, xpos)
-        if (xpos + length) > (80 + 1):
-            raise Exception(
-                "You have exceeded the x-axis limit of the mainframe screen"
-            )
+        if (xpos + length) > (self.model_dimensions["columns"] + 1):
+            raise Exception("You have exceeded the x-axis limit of the mainframe screen")
         # the screen's coordinates are 1 based, but the command is 0 based
         xpos -= 1
         ypos -= 1
-        cmd = self.exec_command(
-            "ascii({0},{1},{2})".format(ypos, xpos, length).encode("utf-8")
-        )
+        cmd = self.exec_command("ascii({0},{1},{2})".format(ypos, xpos, length).encode("utf-8"))
         # this usage of utf-8 should only return a single line of data
         assert len(cmd.data) == 1, cmd.data
         return cmd.data[0].decode("unicode_escape")
@@ -453,8 +492,8 @@ class Emulator(object):
         """
         Check if a string exists on the mainframe screen and return True or False.
         """
-        for ypos in range(24):
-            line = self.string_get(ypos + 1, 1, 80)
+        for ypos in range(self.model_dimensions["rows"]):
+            line = self.string_get(ypos + 1, 1, self.model_dimensions["columns"])
             if ignore_case:
                 line = line.lower()
             if string in line:
@@ -466,8 +505,8 @@ class Emulator(object):
         Read all the mainframe screen and return it in a single string.
         """
         full_text = ""
-        for ypos in range(24):
-            full_text += self.string_get(ypos + 1, 1, 80)
+        for ypos in range(self.model_dimensions["rows"]):
+            full_text += self.string_get(ypos + 1, 1, self.model_dimensions["columns"])
         return full_text
 
     def delete_field(self):
@@ -501,13 +540,8 @@ class Emulator(object):
     def save_screen(self, file_path):
         self.exec_command("PrintText(html,file,{0})".format(file_path).encode("utf-8"))
 
-    @staticmethod
-    def _check_limits(ypos, xpos):
-        if ypos > 24:
-            raise Exception(
-                "You have exceeded the y-axis limit of the mainframe screen"
-            )
-        if xpos > 80:
-            raise Exception(
-                "You have exceeded the x-axis limit of the mainframe screen"
-            )
+    def _check_limits(self, ypos, xpos):
+        if ypos > self.model_dimensions["rows"]:
+            raise Exception("You have exceeded the y-axis limit of the mainframe screen")
+        if xpos > self.model_dimensions["columns"]:
+            raise Exception("You have exceeded the x-axis limit of the mainframe screen")

--- a/Mainframe3270/utils.py
+++ b/Mainframe3270/utils.py
@@ -1,4 +1,5 @@
 from datetime import timedelta
+
 from robot.utils import timestr_to_secs
 
 

--- a/notes.txt
+++ b/notes.txt
@@ -1,0 +1,20 @@
+- Write test for Mainframe3270.__init__
+
+
+Here is what the new structure might look like
+
+```
+Mainframe3270/
+├── __init__.py
+├── keywords
+│   ├── connection.py (contains class ConnectionKeywords)
+     ├── read.py (contains class ReadKeywords)
+      ... etc.
+│   └── __init__.py
+├── py3270.py
+├── librarycomponent.py
+└── version.py
+```
+
+Since we are using pythonlibcore, adding keywords from other classes 
+`librar

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,7 @@
+[tool.black]
+line-length = 120
+target = ['py37']
+
+[tool.isort]
+profile = 'black'
+line_length = 120

--- a/utest/Mainframe3270/keywords/test_assertions.py
+++ b/utest/Mainframe3270/keywords/test_assertions.py
@@ -14,9 +14,7 @@ def under_test():
     return create_test_object_for(AssertionKeywords)
 
 
-def test_page_should_contain_string(
-    mocker: MockerFixture, under_test: AssertionKeywords
-):
+def test_page_should_contain_string(mocker: MockerFixture, under_test: AssertionKeywords):
     mocker.patch("Mainframe3270.py3270.Emulator.string_get", return_value="abc")
     mocker.patch("robot.api.logger.info")
 
@@ -25,9 +23,7 @@ def test_page_should_contain_string(
     logger.info.assert_called_with('The string "abc" was found')
 
 
-def test_page_should_contain_string_ignore_case(
-    mocker: MockerFixture, under_test: AssertionKeywords
-):
+def test_page_should_contain_string_ignore_case(mocker: MockerFixture, under_test: AssertionKeywords):
     mocker.patch("Mainframe3270.py3270.Emulator.string_get", return_value="aBc")
     mocker.patch("robot.api.logger.info")
 
@@ -36,249 +32,179 @@ def test_page_should_contain_string_ignore_case(
     logger.info.assert_called_with('The string "abc" was found')
 
 
-def test_page_should_contain_string_fails(
-    mocker: MockerFixture, under_test: AssertionKeywords
-):
+def test_page_should_contain_string_fails(mocker: MockerFixture, under_test: AssertionKeywords):
     mocker.patch("Mainframe3270.py3270.Emulator.string_get", return_value="abc")
 
     with pytest.raises(Exception, match='The string "def" was not found'):
         under_test.page_should_contain_string("def")
 
 
-def test_page_should_contain_string_custom_message(
-    mocker: MockerFixture, under_test: AssertionKeywords
-):
+def test_page_should_contain_string_custom_message(mocker: MockerFixture, under_test: AssertionKeywords):
     mocker.patch("Mainframe3270.py3270.Emulator.string_get", return_value="abc")
 
     with pytest.raises(Exception, match="my error message"):
         under_test.page_should_contain_string("def", error_message="my error message")
 
 
-def test_page_should_not_contain_string(
-    mocker: MockerFixture, under_test: AssertionKeywords
-):
+def test_page_should_not_contain_string(mocker: MockerFixture, under_test: AssertionKeywords):
     mocker.patch("Mainframe3270.py3270.Emulator.string_get", return_value="abc")
 
     under_test.page_should_not_contain_string("ABC")
 
 
-def test_page_should_not_contain_string_ignore_case(
-    mocker: MockerFixture, under_test: AssertionKeywords
-):
+def test_page_should_not_contain_string_ignore_case(mocker: MockerFixture, under_test: AssertionKeywords):
     mocker.patch("Mainframe3270.py3270.Emulator.string_get", return_value="abc")
 
     under_test.page_should_not_contain_string("def", ignore_case=True)
 
 
-def test_page_should_not_contain_string_fails(
-    mocker: MockerFixture, under_test: AssertionKeywords
-):
+def test_page_should_not_contain_string_fails(mocker: MockerFixture, under_test: AssertionKeywords):
     mocker.patch("Mainframe3270.py3270.Emulator.string_get", return_value="abc")
 
     with pytest.raises(Exception, match='The string "ABC" was found'):
         under_test.page_should_not_contain_string("ABC", ignore_case=True)
 
 
-def test_page_should_not_contain_string_custom_message(
-    mocker: MockerFixture, under_test: AssertionKeywords
-):
+def test_page_should_not_contain_string_custom_message(mocker: MockerFixture, under_test: AssertionKeywords):
     mocker.patch("Mainframe3270.py3270.Emulator.string_get", return_value="abc")
 
     with pytest.raises(Exception, match="my error message"):
-        under_test.page_should_not_contain_string(
-            "abc", error_message="my error message"
-        )
+        under_test.page_should_not_contain_string("abc", error_message="my error message")
 
 
-def test_page_should_contain_any_string(
-    mocker: MockerFixture, under_test: AssertionKeywords
-):
+def test_page_should_contain_any_string(mocker: MockerFixture, under_test: AssertionKeywords):
     mocker.patch("Mainframe3270.py3270.Emulator.string_get", return_value="abc")
 
     under_test.page_should_contain_any_string(["abc", "def"])
 
 
-def test_page_should_contain_any_string_ignore_case(
-    mocker: MockerFixture, under_test: AssertionKeywords
-):
+def test_page_should_contain_any_string_ignore_case(mocker: MockerFixture, under_test: AssertionKeywords):
     mocker.patch("Mainframe3270.py3270.Emulator.string_get", return_value="abc")
 
     under_test.page_should_contain_any_string(["ABC", "def"], ignore_case=True)
 
 
-def test_page_should_contain_any_string_fails(
-    mocker: MockerFixture, under_test: AssertionKeywords
-):
+def test_page_should_contain_any_string_fails(mocker: MockerFixture, under_test: AssertionKeywords):
     mocker.patch("Mainframe3270.py3270.Emulator.string_get", return_value="abc")
 
-    with pytest.raises(
-        Exception, match=re.escape("The strings \"['def', 'ghi']\" were not found")
-    ):
+    with pytest.raises(Exception, match=re.escape("The strings \"['def', 'ghi']\" were not found")):
         under_test.page_should_contain_any_string(["def", "ghi"])
 
 
-def test_page_should_contain_any_string_custom_message(
-    mocker: MockerFixture, under_test: AssertionKeywords
-):
+def test_page_should_contain_any_string_custom_message(mocker: MockerFixture, under_test: AssertionKeywords):
     mocker.patch("Mainframe3270.py3270.Emulator.string_get", return_value="abc")
 
     with pytest.raises(Exception, match="my error message"):
-        under_test.page_should_contain_any_string(
-            ["def", "ghi"], error_message="my error message"
-        )
+        under_test.page_should_contain_any_string(["def", "ghi"], error_message="my error message")
 
 
-def test_page_should_contain_all_strings(
-    mocker: MockerFixture, under_test: AssertionKeywords
-):
+def test_page_should_contain_all_strings(mocker: MockerFixture, under_test: AssertionKeywords):
     mocker.patch("Mainframe3270.py3270.Emulator.string_get", side_effect=["abc", "def"])
 
     under_test.page_should_contain_all_strings(["abc", "def"])
 
 
-def test_page_should_contain_all_strings_ignore_case(
-    mocker: MockerFixture, under_test: AssertionKeywords
-):
+def test_page_should_contain_all_strings_ignore_case(mocker: MockerFixture, under_test: AssertionKeywords):
     mocker.patch("Mainframe3270.py3270.Emulator.string_get", side_effect=["AbC", "DeF"])
 
     under_test.page_should_contain_all_strings(["abc", "def"], ignore_case=True)
 
 
-def test_page_should_contain_all_strings_fails(
-    mocker: MockerFixture, under_test: AssertionKeywords
-):
+def test_page_should_contain_all_strings_fails(mocker: MockerFixture, under_test: AssertionKeywords):
     mocker.patch("Mainframe3270.py3270.Emulator.string_get", return_value=["def"])
 
     with pytest.raises(Exception, match='The string "ghi" was not found'):
         under_test.page_should_contain_all_strings(["def", "ghi"])
 
 
-def test_page_should_contain_all_strings_custom_message(
-    mocker: MockerFixture, under_test: AssertionKeywords
-):
+def test_page_should_contain_all_strings_custom_message(mocker: MockerFixture, under_test: AssertionKeywords):
     mocker.patch("Mainframe3270.py3270.Emulator.string_get", return_value="abc")
 
     with pytest.raises(Exception, match="my error message"):
-        under_test.page_should_contain_all_strings(
-            ["abc", "def"], error_message="my error message"
-        )
+        under_test.page_should_contain_all_strings(["abc", "def"], error_message="my error message")
 
 
-def test_page_should_not_contain_any_string(
-    mocker: MockerFixture, under_test: AssertionKeywords
-):
+def test_page_should_not_contain_any_string(mocker: MockerFixture, under_test: AssertionKeywords):
     mocker.patch("Mainframe3270.py3270.Emulator.string_get", return_value="abc")
 
     under_test.page_should_not_contain_any_string(["def", "ghi"])
 
 
-def test_page_should_not_contain_any_string_fails(
-    mocker: MockerFixture, under_test: AssertionKeywords
-):
+def test_page_should_not_contain_any_string_fails(mocker: MockerFixture, under_test: AssertionKeywords):
     mocker.patch("Mainframe3270.py3270.Emulator.string_get", return_value="abc")
 
     with pytest.raises(Exception, match='The string "abc" was found'):
         under_test.page_should_not_contain_any_string(["abc", "def"])
 
 
-def test_page_should_not_contain_any_string_ignore_case(
-    mocker: MockerFixture, under_test: AssertionKeywords
-):
+def test_page_should_not_contain_any_string_ignore_case(mocker: MockerFixture, under_test: AssertionKeywords):
     mocker.patch("Mainframe3270.py3270.Emulator.string_get", return_value="ABC")
 
     with pytest.raises(Exception, match='The string "abc" was found'):
         under_test.page_should_not_contain_any_string(["abc", "def"], ignore_case=True)
 
 
-def test_page_should_not_contain_any_string_custom_message(
-    mocker: MockerFixture, under_test: AssertionKeywords
-):
+def test_page_should_not_contain_any_string_custom_message(mocker: MockerFixture, under_test: AssertionKeywords):
     mocker.patch("Mainframe3270.py3270.Emulator.string_get", return_value="abc")
 
     with pytest.raises(Exception, match="my error message"):
-        under_test.page_should_not_contain_any_string(
-            ["abc", "def"], error_message="my error message"
-        )
+        under_test.page_should_not_contain_any_string(["abc", "def"], error_message="my error message")
 
 
-def test_page_should_not_contain_all_strings(
-    mocker: MockerFixture, under_test: AssertionKeywords
-):
+def test_page_should_not_contain_all_strings(mocker: MockerFixture, under_test: AssertionKeywords):
     mocker.patch("Mainframe3270.py3270.Emulator.string_get", return_value="abc")
 
     under_test.page_should_not_contain_all_strings(["def", "ghi"])
 
 
-def test_page_should_not_contain_all_strings_ignore_case(
-    mocker: MockerFixture, under_test: AssertionKeywords
-):
+def test_page_should_not_contain_all_strings_ignore_case(mocker: MockerFixture, under_test: AssertionKeywords):
     mocker.patch("Mainframe3270.py3270.Emulator.string_get", return_value="abc")
 
     with pytest.raises(Exception, match='The string "abc" was found'):
         under_test.page_should_not_contain_all_strings(["ABC", "def"], ignore_case=True)
 
 
-def test_page_should_not_contain_all_strings_fails(
-    mocker: MockerFixture, under_test: AssertionKeywords
-):
+def test_page_should_not_contain_all_strings_fails(mocker: MockerFixture, under_test: AssertionKeywords):
     mocker.patch("Mainframe3270.py3270.Emulator.string_get", return_value="abc")
 
     with pytest.raises(Exception, match='The string "abc" was found'):
         under_test.page_should_not_contain_all_strings(["abc", "def"])
 
 
-def test_page_should_not_contain_all_strings_custom_message(
-    mocker: MockerFixture, under_test: AssertionKeywords
-):
+def test_page_should_not_contain_all_strings_custom_message(mocker: MockerFixture, under_test: AssertionKeywords):
     mocker.patch("Mainframe3270.py3270.Emulator.string_get", return_value="abc")
 
     with pytest.raises(Exception, match="my error message"):
-        under_test.page_should_not_contain_all_strings(
-            ["abc", "def"], error_message="my error message"
-        )
+        under_test.page_should_not_contain_all_strings(["abc", "def"], error_message="my error message")
 
 
-def test_page_should_contain_string_x_times(
-    mocker: MockerFixture, under_test: AssertionKeywords
-):
+def test_page_should_contain_string_x_times(mocker: MockerFixture, under_test: AssertionKeywords):
     mocker.patch("Mainframe3270.py3270.Emulator.string_get", return_value="a")
 
     under_test.page_should_contain_string_x_times("a", 24)
 
 
-def test_page_should_contain_string_x_times_ignore_case(
-    mocker: MockerFixture, under_test: AssertionKeywords
-):
+def test_page_should_contain_string_x_times_ignore_case(mocker: MockerFixture, under_test: AssertionKeywords):
     mocker.patch("Mainframe3270.py3270.Emulator.string_get", return_value="a")
 
     under_test.page_should_contain_string_x_times("A", 24, ignore_case=True)
 
 
-def test_page_should_contain_string_x_times_fails(
-    mocker: MockerFixture, under_test: AssertionKeywords
-):
+def test_page_should_contain_string_x_times_fails(mocker: MockerFixture, under_test: AssertionKeywords):
     mocker.patch("Mainframe3270.py3270.Emulator.string_get", return_value="a")
 
-    with pytest.raises(
-        Exception, match='The string "a" was not found "1" times, it appears "24" times'
-    ):
+    with pytest.raises(Exception, match='The string "a" was not found "1" times, it appears "24" times'):
         under_test.page_should_contain_string_x_times("a", 1)
 
-    with pytest.raises(
-        Exception, match='The string "b" was not found "1" times, it appears "0" times'
-    ):
+    with pytest.raises(Exception, match='The string "b" was not found "1" times, it appears "0" times'):
         under_test.page_should_contain_string_x_times("b", 1)
 
 
-def test_page_should_contain_string_x_times_custom_message(
-    mocker: MockerFixture, under_test: AssertionKeywords
-):
+def test_page_should_contain_string_x_times_custom_message(mocker: MockerFixture, under_test: AssertionKeywords):
     mocker.patch("Mainframe3270.py3270.Emulator.string_get", return_value="a")
 
     with pytest.raises(Exception, match="my error message"):
-        under_test.page_should_contain_string_x_times(
-            "b", 1, error_message="my error message"
-        )
+        under_test.page_should_contain_string_x_times("b", 1, error_message="my error message")
 
 
 def test_page_should_match_regex(mocker: MockerFixture, under_test: AssertionKeywords):
@@ -287,108 +213,74 @@ def test_page_should_match_regex(mocker: MockerFixture, under_test: AssertionKey
     under_test.page_should_match_regex(r"\w+")
 
 
-def test_page_should_match_regex_fails(
-    mocker: MockerFixture, under_test: AssertionKeywords
-):
+def test_page_should_match_regex_fails(mocker: MockerFixture, under_test: AssertionKeywords):
     mocker.patch("Mainframe3270.py3270.Emulator.string_get", return_value="abc")
 
-    with pytest.raises(
-        Exception, match=re.escape(r'No matches found for "\d+" pattern')
-    ):
+    with pytest.raises(Exception, match=re.escape(r'No matches found for "\d+" pattern')):
         under_test.page_should_match_regex(r"\d+")
 
 
-def test_page_should_not_match_regex(
-    mocker: MockerFixture, under_test: AssertionKeywords
-):
+def test_page_should_not_match_regex(mocker: MockerFixture, under_test: AssertionKeywords):
     mocker.patch("Mainframe3270.py3270.Emulator.string_get", return_value="abc")
 
     under_test.page_should_not_match_regex(r"\d+")
 
 
-def test_page_should_not_match_regex_fails(
-    mocker: MockerFixture, under_test: AssertionKeywords
-):
+def test_page_should_not_match_regex_fails(mocker: MockerFixture, under_test: AssertionKeywords):
     mocker.patch("Mainframe3270.py3270.Emulator.string_get", return_value="a")
 
-    with pytest.raises(
-        Exception, match=re.escape('There are matches found for "[a]+" pattern')
-    ):
+    with pytest.raises(Exception, match=re.escape('There are matches found for "[a]+" pattern')):
         under_test.page_should_not_match_regex("[a]+")
 
 
-def test_page_should_contain_match(
-    mocker: MockerFixture, under_test: AssertionKeywords
-):
+def test_page_should_contain_match(mocker: MockerFixture, under_test: AssertionKeywords):
     mocker.patch("Mainframe3270.py3270.Emulator.string_get", return_value="abc")
 
     under_test.page_should_contain_match("*a?c*")
 
 
-def test_page_should_contain_match_fails(
-    mocker: MockerFixture, under_test: AssertionKeywords
-):
+def test_page_should_contain_match_fails(mocker: MockerFixture, under_test: AssertionKeywords):
     mocker.patch("Mainframe3270.py3270.Emulator.string_get", return_value="abc")
 
-    with pytest.raises(
-        Exception, match=re.escape('No matches found for "*e?g*" pattern')
-    ):
+    with pytest.raises(Exception, match=re.escape('No matches found for "*e?g*" pattern')):
         under_test.page_should_contain_match("*e?g*")
 
 
-def test_page_should_contain_match_ignore_case(
-    mocker: MockerFixture, under_test: AssertionKeywords
-):
+def test_page_should_contain_match_ignore_case(mocker: MockerFixture, under_test: AssertionKeywords):
     mocker.patch("Mainframe3270.py3270.Emulator.string_get", return_value="ABC")
 
     under_test.page_should_contain_match("*a?c*", ignore_case=True)
 
 
-def test_page_should_contain_match_custom_message(
-    mocker: MockerFixture, under_test: AssertionKeywords
-):
+def test_page_should_contain_match_custom_message(mocker: MockerFixture, under_test: AssertionKeywords):
     mocker.patch("Mainframe3270.py3270.Emulator.string_get", return_value="abc")
 
     with pytest.raises(Exception, match="my error message"):
         under_test.page_should_contain_match("*def*", error_message="my error message")
 
 
-def test_page_should_not_contain_match(
-    mocker: MockerFixture, under_test: AssertionKeywords
-):
+def test_page_should_not_contain_match(mocker: MockerFixture, under_test: AssertionKeywords):
     mocker.patch("Mainframe3270.py3270.Emulator.string_get", return_value="abc")
 
     under_test.page_should_not_contain_match("*def*")
 
 
-def test_page_should_not_contain_match_fails(
-    mocker: MockerFixture, under_test: AssertionKeywords
-):
+def test_page_should_not_contain_match_fails(mocker: MockerFixture, under_test: AssertionKeywords):
     mocker.patch("Mainframe3270.py3270.Emulator.string_get", return_value="abc")
 
-    with pytest.raises(
-        Exception, match=re.escape('There are matches found for "*abc*" pattern')
-    ):
+    with pytest.raises(Exception, match=re.escape('There are matches found for "*abc*" pattern')):
         under_test.page_should_not_contain_match("*abc*")
 
 
-def test_page_should_not_contain_match_ignore_case(
-    mocker: MockerFixture, under_test: AssertionKeywords
-):
+def test_page_should_not_contain_match_ignore_case(mocker: MockerFixture, under_test: AssertionKeywords):
     mocker.patch("Mainframe3270.py3270.Emulator.string_get", return_value="abc")
 
-    with pytest.raises(
-        Exception, match=re.escape('There are matches found for "*abc*" pattern')
-    ):
+    with pytest.raises(Exception, match=re.escape('There are matches found for "*abc*" pattern')):
         under_test.page_should_not_contain_match("*ABC*", ignore_case=True)
 
 
-def test_page_should_not_contain_match_custom_message(
-    mocker: MockerFixture, under_test: AssertionKeywords
-):
+def test_page_should_not_contain_match_custom_message(mocker: MockerFixture, under_test: AssertionKeywords):
     mocker.patch("Mainframe3270.py3270.Emulator.string_get", return_value="abc")
 
     with pytest.raises(Exception, match="my error message"):
-        under_test.page_should_not_contain_match(
-            "*abc*", error_message="my error message"
-        )
+        under_test.page_should_not_contain_match("*abc*", error_message="my error message")

--- a/utest/Mainframe3270/keywords/test_connection.py
+++ b/utest/Mainframe3270/keywords/test_connection.py
@@ -31,9 +31,7 @@ def test_open_connection(mocker: MockerFixture, under_test: ConnectionKeywords):
     assert ConnectionCache.register.call_args[0][1] is None
 
 
-def test_open_connection_with_alias(
-    mocker: MockerFixture, under_test: ConnectionKeywords
-):
+def test_open_connection_with_alias(mocker: MockerFixture, under_test: ConnectionKeywords):
     mocker.patch("Mainframe3270.py3270.Emulator.connect")
     mocker.patch("robot.utils.ConnectionCache.register")
 
@@ -44,9 +42,7 @@ def test_open_connection_with_alias(
     assert ConnectionCache.register.call_args[0][1] == "myalias"
 
 
-def test_open_connection_returns_index(
-    mocker: MockerFixture, under_test: ConnectionKeywords
-):
+def test_open_connection_returns_index(mocker: MockerFixture, under_test: ConnectionKeywords):
     mocker.patch("Mainframe3270.py3270.Emulator.connect")
     mocker.patch("robot.utils.ConnectionCache.register", return_value=1)
 
@@ -63,9 +59,7 @@ def test_open_connection_with_lu(mocker: MockerFixture, under_test: ConnectionKe
     Emulator.connect.assert_called_with("lu@myhost:23")
 
 
-def test_open_connection_with_port(
-    mocker: MockerFixture, under_test: ConnectionKeywords
-):
+def test_open_connection_with_port(mocker: MockerFixture, under_test: ConnectionKeywords):
     mocker.patch("Mainframe3270.py3270.Emulator.connect")
 
     under_test.open_connection("myhost", port=2222)
@@ -73,9 +67,7 @@ def test_open_connection_with_port(
     Emulator.connect.assert_called_with("myhost:2222")
 
 
-def test_open_connection_with_extra_args(
-    mocker: MockerFixture, under_test: ConnectionKeywords
-):
+def test_open_connection_with_extra_args(mocker: MockerFixture, under_test: ConnectionKeywords):
     extra_args = ["-xrm", "*blankFill: true"]
     mocker.patch("Mainframe3270.py3270.Emulator.__init__", return_value=None)
     mocker.patch("Mainframe3270.py3270.Emulator.connect")
@@ -199,9 +191,7 @@ def test_check_session_file_extension(
 
 
 def test_contains_hostname_raises_ValueError(under_test: ConnectionKeywords):
-    with patch(
-        "builtins.open", mock_open(read_data="wc3270.port: 992\n")
-    ) as session_file:
+    with patch("builtins.open", mock_open(read_data="wc3270.port: 992\n")) as session_file:
         with pytest.raises(
             ValueError,
             match="Your session file needs to specify the hostname resource to set up the connection",
@@ -235,9 +225,7 @@ def test_check_model(model: str, under_test: ConnectionKeywords):
         ("*model: 3278-4", "3278-4"),
     ],
 )
-def test_check_model_raises_ValueError(
-    model_string: str, model: SystemError, under_test: ConnectionKeywords
-):
+def test_check_model_raises_ValueError(model_string: str, model: SystemError, under_test: ConnectionKeywords):
     with patch("builtins.open", mock_open(read_data=model_string)) as session_file:
         with pytest.raises(
             ValueError,
@@ -251,12 +239,8 @@ def test_check_model_raises_ValueError(
             under_test._check_model(session_file)
 
 
-def test_open_connection_from_session_file_registers_connection(
-    mocker: MockerFixture, under_test: ConnectionKeywords
-):
-    mocker.patch(
-        "Mainframe3270.keywords.ConnectionKeywords._check_session_file_extension"
-    )
+def test_open_connection_from_session_file_registers_connection(mocker: MockerFixture, under_test: ConnectionKeywords):
+    mocker.patch("Mainframe3270.keywords.ConnectionKeywords._check_session_file_extension")
     mocker.patch("Mainframe3270.keywords.ConnectionKeywords._check_contains_hostname")
     mocker.patch("Mainframe3270.keywords.ConnectionKeywords._check_model")
     mocker.patch("robot.utils.ConnectionCache.register")
@@ -270,9 +254,7 @@ def test_open_connection_from_session_file_registers_connection(
 def test_open_connection_from_session_file_registers_connection_with_alias(
     mocker: MockerFixture, under_test: ConnectionKeywords
 ):
-    mocker.patch(
-        "Mainframe3270.keywords.ConnectionKeywords._check_session_file_extension"
-    )
+    mocker.patch("Mainframe3270.keywords.ConnectionKeywords._check_session_file_extension")
     mocker.patch("Mainframe3270.keywords.ConnectionKeywords._check_contains_hostname")
     mocker.patch("Mainframe3270.keywords.ConnectionKeywords._check_model")
     mocker.patch("robot.utils.ConnectionCache.register")
@@ -283,12 +265,8 @@ def test_open_connection_from_session_file_registers_connection_with_alias(
     assert ConnectionCache.register.call_args[0][1] == "myalias"
 
 
-def test_open_connection_from_session_file_returns_index(
-    mocker: MockerFixture, under_test: ConnectionKeywords
-):
-    mocker.patch(
-        "Mainframe3270.keywords.ConnectionKeywords._check_session_file_extension"
-    )
+def test_open_connection_from_session_file_returns_index(mocker: MockerFixture, under_test: ConnectionKeywords):
+    mocker.patch("Mainframe3270.keywords.ConnectionKeywords._check_session_file_extension")
     mocker.patch("Mainframe3270.keywords.ConnectionKeywords._check_contains_hostname")
     mocker.patch("Mainframe3270.keywords.ConnectionKeywords._check_model")
     mocker.patch("robot.utils.ConnectionCache.register", return_value=1)

--- a/utest/Mainframe3270/keywords/test_read_write.py
+++ b/utest/Mainframe3270/keywords/test_read_write.py
@@ -22,9 +22,7 @@ def test_read(under_test: ReadWriteKeywords, mocker: MockerFixture):
 
 
 def test_read_all_screen(under_test: ReadWriteKeywords, mocker: MockerFixture):
-    mocker.patch(
-        "Mainframe3270.py3270.Emulator.read_all_screen", return_value="all screen"
-    )
+    mocker.patch("Mainframe3270.py3270.Emulator.read_all_screen", return_value="all screen")
 
     content = under_test.read_all_screen()
 

--- a/utest/Mainframe3270/keywords/test_screenshot.py
+++ b/utest/Mainframe3270/keywords/test_screenshot.py
@@ -22,9 +22,7 @@ def test_set_screenshot_folder(under_test: ScreenshotKeywords):
     assert under_test.img_folder == os.getcwd()
 
 
-def test_set_screenshot_folder_nonexistent(
-    mocker: MockerFixture, under_test: ScreenshotKeywords
-):
+def test_set_screenshot_folder_nonexistent(mocker: MockerFixture, under_test: ScreenshotKeywords):
     mocker.patch("robot.api.logger.error")
     mocker.patch("robot.api.logger.warn")
     path = os.path.join(os.getcwd(), "nonexistent")
@@ -32,9 +30,7 @@ def test_set_screenshot_folder_nonexistent(
     under_test.set_screenshot_folder(path)
 
     logger.error.assert_called_with('Given screenshots path "%s" does not exist' % path)
-    logger.warn.assert_called_with(
-        'Screenshots will be saved in "%s"' % under_test.img_folder
-    )
+    logger.warn.assert_called_with('Screenshots will be saved in "%s"' % under_test.img_folder)
 
 
 def test_take_screenshot(mocker: MockerFixture, under_test: ScreenshotKeywords):
@@ -55,9 +51,7 @@ def test_take_screenshot(mocker: MockerFixture, under_test: ScreenshotKeywords):
         assert filepath == "./screenshot_1000.html"
 
 
-def test_take_screenshot_with_filename_prefix(
-    mocker: MockerFixture, under_test: ScreenshotKeywords
-):
+def test_take_screenshot_with_filename_prefix(mocker: MockerFixture, under_test: ScreenshotKeywords):
     mocker.patch("Mainframe3270.py3270.Emulator.save_screen")
     mocker.patch("robot.api.logger.write")
     mocker.patch("time.time", return_value=1.0)

--- a/utest/Mainframe3270/keywords/test_wait_and_timeout.py
+++ b/utest/Mainframe3270/keywords/test_wait_and_timeout.py
@@ -86,27 +86,21 @@ def test_wait_until_string(mocker: MockerFixture, under_test: WaitAndTimeoutKeyw
     assert txt == "abc"
 
 
-def test_wait_until_string_string_not_found(
-    mocker: MockerFixture, under_test: WaitAndTimeoutKeywords
-):
+def test_wait_until_string_string_not_found(mocker: MockerFixture, under_test: WaitAndTimeoutKeywords):
     mocker.patch("Mainframe3270.py3270.Emulator.string_get", return_value="abc")
 
     with pytest.raises(Exception, match='String "def" not found in 1 second'):
         under_test.wait_until_string("def", 1)
 
 
-def test_wait_until_string_with_time_time_string(
-    mocker: MockerFixture, under_test: WaitAndTimeoutKeywords
-):
+def test_wait_until_string_with_time_time_string(mocker: MockerFixture, under_test: WaitAndTimeoutKeywords):
     mocker.patch("Mainframe3270.py3270.Emulator.string_get", return_value="abc")
 
     with pytest.raises(Exception, match='String "def" not found in 500 milliseconds'):
         under_test.wait_until_string("def", "500 millis")
 
 
-def test_wait_until_string_with_time_timer_string(
-    mocker: MockerFixture, under_test: WaitAndTimeoutKeywords
-):
+def test_wait_until_string_with_time_timer_string(mocker: MockerFixture, under_test: WaitAndTimeoutKeywords):
     mocker.patch("Mainframe3270.py3270.Emulator.string_get", return_value="abc")
 
     with pytest.raises(Exception, match='String "def" not found in 500 milliseconds'):

--- a/utest/Mainframe3270/test__init__.py
+++ b/utest/Mainframe3270/test__init__.py
@@ -12,6 +12,7 @@ def test_default_args():
     assert under_test.wait_time == 0.5
     assert under_test.wait_time_after_write == 0.0
     assert under_test.img_folder == "."
+    assert under_test.model == "2"
     under_test.mf is None
 
 

--- a/utest/Mainframe3270/test_librarycomponent.py
+++ b/utest/Mainframe3270/test_librarycomponent.py
@@ -21,6 +21,7 @@ def test_librarycomponent_returns_common_attributes():
     assert library.cache == under_test.cache
     assert library.mf == under_test.mf
     assert library.output_folder == under_test.output_folder
+    assert library.model == under_test.model
 
 
 def test_can_set_visible():

--- a/utest/Mainframe3270/test_run_on_failure.py
+++ b/utest/Mainframe3270/test_run_on_failure.py
@@ -36,6 +36,4 @@ def test_run_on_failure_could_not_be_run(mocker: MockerFixture):
 
     with pytest.raises(Exception, match="my error message"):
         under_test.run_keyword("Keyword", None, None)
-        logger.warn.assert_called_with(
-            "Keyword 'Keyword' could not be run on failure: my error message"
-        )
+        logger.warn.assert_called_with("Keyword 'Keyword' could not be run on failure: my error message")

--- a/utest/py3270/test_command.py
+++ b/utest/py3270/test_command.py
@@ -4,8 +4,7 @@ import pytest
 from pytest_mock import MockerFixture
 
 # fmt: off
-from Mainframe3270.py3270 import (Command, CommandError, Emulator, s3270App,
-                                  wc3270App, ws3270App, x3270App)
+from Mainframe3270.py3270 import Command, CommandError, Emulator, s3270App, wc3270App, ws3270App, x3270App
 
 # fmt: on
 
@@ -93,7 +92,5 @@ def test_handle_result_not_ok_or_error(mocker: MockerFixture):
     app = wc3270App()
     under_test = Command(app, b"abc")
 
-    with pytest.raises(
-        ValueError, match='expected "ok" or "error" result, but received: abc'
-    ):
+    with pytest.raises(ValueError, match='expected "ok" or "error" result, but received: abc'):
         under_test.execute()

--- a/utest/py3270/test_emulator.py
+++ b/utest/py3270/test_emulator.py
@@ -51,22 +51,56 @@ def test_emulator_with_extra_args():
 
 
 @pytest.mark.usefixtures("mock_windows")
+def test_emulator_with_model_default_model():
+    under_test = Emulator()
+
+    assert under_test.model == "2", 'default model should be "2"'
+
+
+@pytest.mark.usefixtures("mock_windows")
+def test_emulator_with_model():
+    under_test = Emulator(model="4")
+
+    assert under_test.model == "4"
+
+
+@pytest.mark.usefixtures("mock_windows")
+@pytest.mark.parametrize(
+    ("model", "model_dimensions"),
+    [
+        ("2", {"rows": 24, "columns": 80}),
+        ("3", {"rows": 32, "columns": 80}),
+        ("4", {"rows": 43, "columns": 80}),
+        ("5", {"rows": 27, "columns": 132}),
+    ],
+)
+def test_emulator_sets_model_dimensions(model, model_dimensions):
+    under_test = Emulator(model=model)
+
+    assert under_test.model_dimensions == model_dimensions
+
+
+@pytest.mark.usefixtures("mock_windows")
+def test_set_model_dimensions_raises_ValueError():
+    under_test = Emulator()
+
+    with pytest.raises(KeyError, match=r"Model should be one of .+, but was 'wrong model'"):
+        under_test._set_model_dimensions("wrong model")
+
+
+@pytest.mark.usefixtures("mock_windows")
 def test_exec_command_when_is_terminated():
     under_test = Emulator()
     under_test.is_terminated = True
 
-    with pytest.raises(
-        TerminatedError, match="This Emulator instance has been terminated"
-    ):
+    with pytest.raises(TerminatedError, match="This Emulator instance has been terminated"):
         under_test.exec_command(b"abc")
 
 
 @pytest.mark.usefixtures("mock_windows")
 def test_terminate_BrokenPipeError(mocker: MockerFixture):
     mocker.patch("Mainframe3270.py3270.wc3270App.close")
-    mocker.patch(
-        "Mainframe3270.py3270.Emulator.exec_command", side_effect=BrokenPipeError
-    )
+    mocker.patch("Mainframe3270.py3270.Emulator.exec_command", side_effect=BrokenPipeError)
     under_test = Emulator()
 
     under_test.terminate()
@@ -79,9 +113,7 @@ def test_terminate_socket_error(mocker: MockerFixture):
     mock_os_error = OSError()
     mock_os_error.errno = errno.ECONNRESET
     mocker.patch("Mainframe3270.py3270.wc3270App.close")
-    mocker.patch(
-        "Mainframe3270.py3270.Emulator.exec_command", side_effect=mock_os_error
-    )
+    mocker.patch("Mainframe3270.py3270.Emulator.exec_command", side_effect=mock_os_error)
     under_test = Emulator()
 
     under_test.terminate()
@@ -176,13 +208,21 @@ def test_string_get_calls__check_limits(mocker: MockerFixture):
 
 
 @pytest.mark.usefixtures("mock_windows")
-def test_string_get_exceeds_x_axis(mocker: MockerFixture):
-    under_test = Emulator(True)
+@pytest.mark.parametrize(
+    ("model", "length"),
+    [
+        ("2", 72),
+        ("3", 72),
+        ("4", 72),
+        ("5", 124),
+    ],
+)
+def test_string_get_exceeds_x_axis(mocker: MockerFixture, model: str, length: int):
+    mocker.patch("Mainframe3270.py3270.wc3270App.readline")
+    under_test = Emulator(True, model=model)
 
-    with pytest.raises(
-        Exception, match="You have exceeded the x-axis limit of the mainframe screen"
-    ):
-        under_test.string_get(1, 10, 72)
+    with pytest.raises(Exception, match="You have exceeded the x-axis limit of the mainframe screen"):
+        under_test.string_get(1, 10, length)
 
 
 @pytest.mark.usefixtures("mock_windows")
@@ -210,6 +250,18 @@ def test_search_string_ignoring_case(mocker: MockerFixture):
 
 
 @pytest.mark.usefixtures("mock_windows")
+@pytest.mark.parametrize(("model", "rows", "columns"), [("2", 24, 80), ("3", 32, 80), ("4", 43, 80), ("5", 27, 132)])
+def test_search_string_with_different_model_dimensions(mocker: MockerFixture, model: str, rows: int, columns: int):
+    mocker.patch("Mainframe3270.py3270.Emulator.string_get")
+    under_test = Emulator(model=model)
+
+    under_test.search_string("abc")
+
+    assert Emulator.string_get.call_count == rows
+    Emulator.string_get.assert_called_with(rows, 1, columns)
+
+
+@pytest.mark.usefixtures("mock_windows")
 def test_read_all_screen(mocker: MockerFixture):
     mocker.patch("Mainframe3270.py3270.Emulator.string_get", return_value="a")
     under_test = Emulator()
@@ -217,6 +269,18 @@ def test_read_all_screen(mocker: MockerFixture):
     content = under_test.read_all_screen()
 
     assert content == "a" * 24
+
+
+@pytest.mark.usefixtures("mock_windows")
+@pytest.mark.parametrize(("model", "rows", "columns"), [("2", 24, 80), ("3", 32, 80), ("4", 43, 80), ("5", 27, 132)])
+def test_read_all_screen_with_different_model_dimensions(mocker: MockerFixture, model: str, rows: int, columns: int):
+    mocker.patch("Mainframe3270.py3270.Emulator.string_get")
+    under_test = Emulator(model=model)
+
+    under_test.read_all_screen()
+
+    assert Emulator.string_get.call_count == rows
+    Emulator.string_get.assert_called_with(rows, 1, columns)
 
 
 @pytest.mark.usefixtures("mock_windows")
@@ -228,14 +292,20 @@ def test_check_limits():
 
 @pytest.mark.usefixtures("mock_windows")
 @pytest.mark.parametrize(
-    ("ypos", "xpos", "expected_error"),
+    ("model", "ypos", "xpos", "expected_error"),
     [
-        (25, 80, "You have exceeded the y-axis limit of the mainframe screen"),
-        (24, 81, "You have exceeded the x-axis limit of the mainframe screen"),
+        ("2", 25, 80, "You have exceeded the y-axis limit of the mainframe screen"),
+        ("3", 33, 80, "You have exceeded the y-axis limit of the mainframe screen"),
+        ("4", 44, 80, "You have exceeded the y-axis limit of the mainframe screen"),
+        ("5", 28, 80, "You have exceeded the y-axis limit of the mainframe screen"),
+        ("2", 24, 81, "You have exceeded the x-axis limit of the mainframe screen"),
+        ("3", 32, 81, "You have exceeded the x-axis limit of the mainframe screen"),
+        ("4", 43, 81, "You have exceeded the x-axis limit of the mainframe screen"),
+        ("5", 27, 133, "You have exceeded the x-axis limit of the mainframe screen"),
     ],
 )
-def test_check_limits_raises_Exception(ypos, xpos, expected_error):
-    under_test = Emulator()
+def test_check_limits_raises_Exception(model, ypos, xpos, expected_error):
+    under_test = Emulator(model=model)
 
     with pytest.raises(Exception, match=expected_error):
         under_test._check_limits(ypos, xpos)


### PR DESCRIPTION
This would be my take on issue #31 , I am not sure if I will robot framework tests for this one, since we do not have access to a mainframe that supports different model.

As you can see in the documentation, I propose that we publish this as an experimental feature, so that users are aware that this feature is not yet stable.