### PR TITLE
#117 Create Get String Positions Only Before / After keywords

### DIFF
--- a/Mainframe3270/keywords/commands.py
+++ b/Mainframe3270/keywords/commands.py
@@ -1,11 +1,10 @@
 import time
 from typing import Optional, Union
 
-from robot.api import logger
 from robot.api.deco import keyword
 
 from Mainframe3270.librarycomponent import LibraryComponent
-from Mainframe3270.utils import SearchResultMode, coordinates_to_dict
+from Mainframe3270.utils import SearchResultMode, prepare_position_as
 
 
 class CommandKeywords(LibraryComponent):
@@ -97,14 +96,8 @@ class CommandKeywords(LibraryComponent):
             | Get Cursor Position | As Dict | # Returns a position like {"xpos": 1, "ypos": 1} |
 
         """
-        ypos, xpos = self.mf.get_current_position()
-        if mode == SearchResultMode.As_Dict:
-            return coordinates_to_dict(ypos, xpos)
-        elif mode == SearchResultMode.As_Tuple:
-            return ypos, xpos
-        else:
-            logger.warn('"mode" should be either "as dict" or "as tuple". Returning the result as tuple')
-            return ypos, xpos
+        position = self.mf.get_current_position()
+        return prepare_position_as(position, mode)
 
     @keyword("Move Cursor To")
     def move_cursor_to(self, ypos: int, xpos: int):

--- a/Mainframe3270/keywords/commands.py
+++ b/Mainframe3270/keywords/commands.py
@@ -4,7 +4,7 @@ from typing import Optional, Union
 from robot.api.deco import keyword
 
 from Mainframe3270.librarycomponent import LibraryComponent
-from Mainframe3270.utils import SearchResultMode, prepare_position_as
+from Mainframe3270.utils import ResultMode, prepare_position_as
 
 
 class CommandKeywords(LibraryComponent):
@@ -85,7 +85,7 @@ class CommandKeywords(LibraryComponent):
         time.sleep(self.wait_time)
 
     @keyword("Get Current Position")
-    def get_current_position(self, mode: SearchResultMode = SearchResultMode.As_Tuple) -> Union[tuple, dict]:
+    def get_current_position(self, mode: ResultMode = ResultMode.As_Tuple) -> Union[tuple, dict]:
         """Returns the current cursor position. The coordinates are 1 based.
 
         By default, this keyword returns a tuple of integers. However, if you specify the `mode` with the value

--- a/Mainframe3270/keywords/commands.py
+++ b/Mainframe3270/keywords/commands.py
@@ -5,7 +5,7 @@ from robot.api import logger
 from robot.api.deco import keyword
 
 from Mainframe3270.librarycomponent import LibraryComponent
-from Mainframe3270.utils import coordinates_to_dict
+from Mainframe3270.utils import SearchResultMode, coordinates_to_dict
 
 
 class CommandKeywords(LibraryComponent):
@@ -86,7 +86,7 @@ class CommandKeywords(LibraryComponent):
         time.sleep(self.wait_time)
 
     @keyword("Get Current Position")
-    def get_current_position(self, mode: str = "As Tuple") -> Union[tuple, dict]:
+    def get_current_position(self, mode: SearchResultMode = SearchResultMode.As_Tuple) -> Union[tuple, dict]:
         """Returns the current cursor position. The coordinates are 1 based.
 
         By default, this keyword returns a tuple of integers. However, if you specify the `mode` with the value
@@ -98,9 +98,9 @@ class CommandKeywords(LibraryComponent):
 
         """
         ypos, xpos = self.mf.get_current_position()
-        if mode.lower() == "as dict":
+        if mode == SearchResultMode.As_Dict:
             return coordinates_to_dict(ypos, xpos)
-        elif mode.lower() == "as tuple":
+        elif mode == SearchResultMode.As_Tuple:
             return ypos, xpos
         else:
             logger.warn('"mode" should be either "as dict" or "as tuple". Returning the result as tuple')

--- a/Mainframe3270/keywords/read_write.py
+++ b/Mainframe3270/keywords/read_write.py
@@ -1,5 +1,5 @@
 import time
-from typing import Any, Optional
+from typing import Any, List, Optional
 
 from robot.api import logger
 from robot.api.deco import keyword
@@ -61,13 +61,7 @@ class ReadWriteKeywords(LibraryComponent):
             | ${positions} | Get String Positions | Abc | As Dict | # Returns a list like [{"ypos": 1, "xpos": 8}] |
         """
         results = self.mf.get_string_positions(string, ignore_case)
-        if mode == SearchResultMode.As_Dict:
-            return [coordinates_to_dict(ypos, xpos) for ypos, xpos in results]
-        elif mode == SearchResultMode.As_Tuple:
-            return results
-        else:
-            logger.warn('"mode" should be either "as dict" or "as tuple". Returning the result as tuple')
-            return results
+        return ReadWriteKeywords._prepare_result_positions(mode, results)
 
     @keyword("Get String Positions Only After")
     def get_string_positions_only_after(
@@ -93,13 +87,7 @@ class ReadWriteKeywords(LibraryComponent):
         self.mf.check_limits(ypos, xpos)
         results = self.mf.get_string_positions(string, ignore_case)
         filtered = [result for result in results if result > (ypos, xpos)]
-        if mode == SearchResultMode.As_Dict:
-            return [coordinates_to_dict(ypos, xpos) for ypos, xpos in filtered]
-        elif mode == SearchResultMode.As_Tuple:
-            return filtered
-        else:
-            logger.warn('"mode" should be either "as dict" or "as tuple". Returning the result as tuple')
-            return filtered
+        return ReadWriteKeywords._prepare_result_positions(mode, filtered)
 
     @keyword("Get String Positions Only Before")
     def get_string_positions_only_before(
@@ -125,13 +113,7 @@ class ReadWriteKeywords(LibraryComponent):
         self.mf.check_limits(ypos, xpos)
         results = self.mf.get_string_positions(string, ignore_case)
         filtered = [result for result in results if result < (ypos, xpos)]
-        if mode == SearchResultMode.As_Dict:
-            return [coordinates_to_dict(ypos, xpos) for ypos, xpos in filtered]
-        elif mode == SearchResultMode.As_Tuple:
-            return filtered
-        else:
-            logger.warn('"mode" should be either "as dict" or "as tuple". Returning the result as tuple')
-            return filtered
+        ReadWriteKeywords._prepare_result_positions(mode, filtered)
 
     @keyword("Write")
     def write(self, txt: str) -> None:
@@ -191,3 +173,13 @@ class ReadWriteKeywords(LibraryComponent):
         if enter:
             self.mf.send_enter()
             time.sleep(self.wait_time)
+
+    @staticmethod
+    def _prepare_result_positions(mode: SearchResultMode, results: List[tuple]):
+        if mode == SearchResultMode.As_Dict:
+            return [coordinates_to_dict(ypos, xpos) for ypos, xpos in results]
+        elif mode == SearchResultMode.As_Tuple:
+            return results
+        else:
+            logger.warn('"mode" should be either "as dict" or "as tuple". Returning the result as tuple')
+            return results

--- a/Mainframe3270/keywords/read_write.py
+++ b/Mainframe3270/keywords/read_write.py
@@ -90,8 +90,41 @@ class ReadWriteKeywords(LibraryComponent):
             | ${positions} | Get String Positions Only After | 5 | 4 | Abc |         | # Returns a list like [(5, 5)] |
             | ${positions} | Get String Positions Only After | 5 | 4 | Abc | As Dict | # Returns a list like [{"ypos": 5, "xpos": 5}] |
         """
+        self.mf._check_limits(ypos, xpos)
         results = self.mf.get_string_positions(string, ignore_case)
         filtered = [result for result in results if result > (ypos, xpos)]
+        if mode == SearchResultMode.As_Dict:
+            return [coordinates_to_dict(ypos, xpos) for ypos, xpos in filtered]
+        elif mode == SearchResultMode.As_Tuple:
+            return filtered
+        else:
+            logger.warn('"mode" should be either "as dict" or "as tuple". Returning the result as tuple')
+            return filtered
+
+    @keyword("Get String Positions Only Before")
+    def get_string_positions_only_before(
+        self,
+        ypos: int,
+        xpos: int,
+        string: str,
+        mode: SearchResultMode = SearchResultMode.As_Tuple,
+        ignore_case: bool = False,
+    ):
+        """Returns a list of tuples of ypos and xpos for the position where the `string` was found,
+        but only before the specified ypos/xpos coordinates. If it is not found an empty list is returned.
+
+        If you specify the `mode` with the value `"As Dict"` (case-insensitive),
+        a list of dictionaries in the form of ``[{"xpos": int, "ypos": int}]`` is returned.
+
+        If `ignore_case` is set to `True`, then the search is done case-insensitively.
+
+        Example:
+            | ${positions} | Get String Positions Only Before | 11 | 20 | Abc |         | # Returns a list like [(11, 19)] |
+            | ${positions} | Get String Positions Only Before | 11 | 20 | Abc | As Dict | # Returns a list like [{"ypos": 11, "xpos": 19}] |
+        """
+        self.mf._check_limits(ypos, xpos)
+        results = self.mf.get_string_positions(string, ignore_case)
+        filtered = [result for result in results if result < (ypos, xpos)]
         if mode == SearchResultMode.As_Dict:
             return [coordinates_to_dict(ypos, xpos) for ypos, xpos in filtered]
         elif mode == SearchResultMode.As_Tuple:

--- a/Mainframe3270/keywords/read_write.py
+++ b/Mainframe3270/keywords/read_write.py
@@ -113,7 +113,7 @@ class ReadWriteKeywords(LibraryComponent):
         self.mf.check_limits(ypos, xpos)
         results = self.mf.get_string_positions(string, ignore_case)
         filtered = [result for result in results if result < (ypos, xpos)]
-        ReadWriteKeywords._prepare_result_positions(mode, filtered)
+        return ReadWriteKeywords._prepare_result_positions(mode, filtered)
 
     @keyword("Write")
     def write(self, txt: str) -> None:

--- a/Mainframe3270/keywords/read_write.py
+++ b/Mainframe3270/keywords/read_write.py
@@ -90,7 +90,7 @@ class ReadWriteKeywords(LibraryComponent):
             | ${positions} | Get String Positions Only After | 5 | 4 | Abc |         | # Returns a list like [(5, 5)] |
             | ${positions} | Get String Positions Only After | 5 | 4 | Abc | As Dict | # Returns a list like [{"ypos": 5, "xpos": 5}] |
         """
-        self.mf._check_limits(ypos, xpos)
+        self.mf.check_limits(ypos, xpos)
         results = self.mf.get_string_positions(string, ignore_case)
         filtered = [result for result in results if result > (ypos, xpos)]
         if mode == SearchResultMode.As_Dict:
@@ -122,7 +122,7 @@ class ReadWriteKeywords(LibraryComponent):
             | ${positions} | Get String Positions Only Before | 11 | 20 | Abc |         | # Returns a list like [(11, 19)] |
             | ${positions} | Get String Positions Only Before | 11 | 20 | Abc | As Dict | # Returns a list like [{"ypos": 11, "xpos": 19}] |
         """
-        self.mf._check_limits(ypos, xpos)
+        self.mf.check_limits(ypos, xpos)
         results = self.mf.get_string_positions(string, ignore_case)
         filtered = [result for result in results if result < (ypos, xpos)]
         if mode == SearchResultMode.As_Dict:

--- a/Mainframe3270/keywords/read_write.py
+++ b/Mainframe3270/keywords/read_write.py
@@ -4,7 +4,7 @@ from typing import Any, Optional
 from robot.api.deco import keyword
 
 from Mainframe3270.librarycomponent import LibraryComponent
-from Mainframe3270.utils import SearchResultMode, prepare_positions_as
+from Mainframe3270.utils import ResultMode, prepare_positions_as
 
 
 class ReadWriteKeywords(LibraryComponent):
@@ -44,9 +44,7 @@ class ReadWriteKeywords(LibraryComponent):
         return self.mf.read_all_screen()
 
     @keyword("Get String Positions")
-    def get_string_positions(
-        self, string: str, mode: SearchResultMode = SearchResultMode.As_Tuple, ignore_case: bool = False
-    ):
+    def get_string_positions(self, string: str, mode: ResultMode = ResultMode.As_Tuple, ignore_case: bool = False):
         """Returns a list of tuples of ypos and xpos for the position where the `string` was found,
         or an empty list if it was not found.
 
@@ -68,7 +66,7 @@ class ReadWriteKeywords(LibraryComponent):
         ypos: int,
         xpos: int,
         string: str,
-        mode: SearchResultMode = SearchResultMode.As_Tuple,
+        mode: ResultMode = ResultMode.As_Tuple,
         ignore_case: bool = False,
     ):
         """Returns a list of tuples of ypos and xpos for the position where the `string` was found,
@@ -94,7 +92,7 @@ class ReadWriteKeywords(LibraryComponent):
         ypos: int,
         xpos: int,
         string: str,
-        mode: SearchResultMode = SearchResultMode.As_Tuple,
+        mode: ResultMode = ResultMode.As_Tuple,
         ignore_case: bool = False,
     ):
         """Returns a list of tuples of ypos and xpos for the position where the `string` was found,

--- a/Mainframe3270/py3270.py
+++ b/Mainframe3270/py3270.py
@@ -431,7 +431,7 @@ class Emulator(object):
         move the cursor to the given coordinates.  Coordinates are 1
         based, as listed in the status area of the terminal.
         """
-        self._check_limits(ypos, xpos)
+        self.check_limits(ypos, xpos)
         # the screen's coordinates are 1 based, but the command is 0 based
         xpos -= 1
         ypos -= 1
@@ -461,7 +461,7 @@ class Emulator(object):
         Coordinates are 1 based, as listed in the status area of the
         terminal.
         """
-        self._check_limits(ypos, xpos)
+        self.check_limits(ypos, xpos)
         if (xpos + length) > (self.model_dimensions["columns"] + 1):
             raise Exception("You have exceeded the x-axis limit of the mainframe screen")
         # the screen's coordinates are 1 based, but the command is 0 based
@@ -542,7 +542,7 @@ class Emulator(object):
         list_of_strings = command.data[0].decode("utf-8").split(" ")
         return tuple([int(i) + 1 for i in list_of_strings])
 
-    def _check_limits(self, ypos, xpos):
+    def check_limits(self, ypos, xpos):
         if ypos > self.model_dimensions["rows"]:
             raise Exception("You have exceeded the y-axis limit of the mainframe screen")
         if xpos > self.model_dimensions["columns"]:

--- a/Mainframe3270/utils.py
+++ b/Mainframe3270/utils.py
@@ -1,12 +1,31 @@
 from datetime import timedelta
 from enum import Enum, auto
+from typing import List, Tuple
 
+from robot.api import logger
 from robot.utils import timestr_to_secs
 
 
 class SearchResultMode(Enum):
     As_Tuple = auto()
     As_Dict = auto()
+
+
+def prepare_position_as(position: Tuple[int, int], mode: SearchResultMode):
+    return prepare_positions_as([position], mode)[0]
+
+
+def prepare_positions_as(positions: List[Tuple[int, int]], mode: SearchResultMode):
+    if mode == SearchResultMode.As_Dict:
+        return [coordinates_to_dict(ypos, xpos) for ypos, xpos in positions]
+    elif mode == SearchResultMode.As_Tuple:
+        return positions
+    else:
+        logger.warn(
+            f'"mode" should be either "{SearchResultMode.As_Dict}" or "{SearchResultMode.As_Tuple}". '
+            "Returning the result as tuple"
+        )
+        return positions
 
 
 def convert_timeout(time):

--- a/Mainframe3270/utils.py
+++ b/Mainframe3270/utils.py
@@ -6,23 +6,23 @@ from robot.api import logger
 from robot.utils import timestr_to_secs
 
 
-class SearchResultMode(Enum):
+class ResultMode(Enum):
     As_Tuple = auto()
     As_Dict = auto()
 
 
-def prepare_position_as(position: Tuple[int, int], mode: SearchResultMode):
+def prepare_position_as(position: Tuple[int, int], mode: ResultMode):
     return prepare_positions_as([position], mode)[0]
 
 
-def prepare_positions_as(positions: List[Tuple[int, int]], mode: SearchResultMode):
-    if mode == SearchResultMode.As_Dict:
+def prepare_positions_as(positions: List[Tuple[int, int]], mode: ResultMode):
+    if mode == ResultMode.As_Dict:
         return [coordinates_to_dict(ypos, xpos) for ypos, xpos in positions]
-    elif mode == SearchResultMode.As_Tuple:
+    elif mode == ResultMode.As_Tuple:
         return positions
     else:
         logger.warn(
-            f'"mode" should be either "{SearchResultMode.As_Dict}" or "{SearchResultMode.As_Tuple}". '
+            f'"mode" should be either "{ResultMode.As_Dict}" or "{ResultMode.As_Tuple}". '
             "Returning the result as tuple"
         )
         return positions

--- a/Mainframe3270/utils.py
+++ b/Mainframe3270/utils.py
@@ -1,6 +1,12 @@
 from datetime import timedelta
+from enum import Enum, auto
 
 from robot.utils import timestr_to_secs
+
+
+class SearchResultMode(Enum):
+    As_Tuple = auto()
+    As_Dict = auto()
 
 
 def convert_timeout(time):

--- a/atest/mainframe.robot
+++ b/atest/mainframe.robot
@@ -259,23 +259,39 @@ Test Get Current Position
     Should Be Equal    ${{ {"xpos": 27, "ypos": 6} }}    ${position_as_dict}
 
 Test Get String Positions
-    ${position}    Get String Positions    Welcome
-    Should Be Equal    ${{ [(1, 10)] }}    ${position}
+    ${positions}    Get String Positions    Welcome
+    Should Be Equal    ${{ [(1, 10)] }}    ${positions}
 
 Test Get String Positions Case-Insensitive
-    ${position}    Get String Positions    Welcome    ignore_case=True
-    Should Be Equal    ${{ [(1, 10), (9, 5)] }}    ${position}
+    ${positions}    Get String Positions    Welcome    ignore_case=True
+    Should Be Equal    ${{ [(1, 10), (9, 5)] }}    ${positions}
 
 Test Get String Positions As Dict
-    ${position}    Get String Positions    Welcome    As Dict
+    ${positions}    Get String Positions    Welcome    As Dict
     Should Be Equal    ${{ [{"ypos": 1, "xpos": 10}] }}
-    ...    ${position}
+    ...    ${positions}
 
 Test Get String Positions Without Result
-    ${position}    Get String Positions    ${STRING_NON_EXISTENT}
-    Should Be Equal    ${{ [] }}    ${position}
-    ${position}    Get String Positions    ${STRING_NON_EXISTENT}    As Dict
-    Should Be Equal    ${{ [] }}    ${position}
+    ${positions}    Get String Positions    ${STRING_NON_EXISTENT}
+    Should Be Equal    ${{ [] }}    ${positions}
+    ${positions}    Get String Positions    ${STRING_NON_EXISTENT}    As Dict
+    Should Be Equal    ${{ [] }}    ${positions}
+
+Test Get String Positions Only After
+    ${positions}    Get String Positions Only After    5    10    name
+    Should Be Equal    ${{ [(5, 11), (21, 38)] }}    ${positions}
+
+Test Get String Positions Only After As Dict
+    ${positions}    Get String Positions Only After    5    10    name    As Dict
+    Should Be Equal    ${{ [{'ypos': 5, 'xpos': 11}, {'ypos': 21, 'xpos': 38}] }}    ${positions}
+
+Test Get String Positions Only After Case-Insensitive
+    ${positions}    Get String Positions Only After    9    4    Welcome    ignore_case=True
+    Should Be Equal    ${{ [(9, 5)] }}    ${positions}
+
+Test Get String Positions Only After Without Results
+    ${positions}    Get String Positions Only After    9    5    Welcome    ignore_case=True
+    Should Be Empty    ${positions}
 
 
 *** Keywords ***

--- a/atest/mainframe.robot
+++ b/atest/mainframe.robot
@@ -122,6 +122,18 @@ Exception Test Move Cursor To
     Run Keyword And Expect Error    ${X_AXIS_EXCEEDED_EXPECTED_ERROR}
     ...    Move Cursor To    1    81
 
+Exception Test Get String Positions Only After
+    Run Keyword And Expect Error    ${Y_AXIS_EXCEEDED_EXPECTED_ERROR}    Get String Positions Only After
+    ...    25    1    my search string
+    Run Keyword And Expect Error    ${X_AXIS_EXCEEDED_EXPECTED_ERROR}    Get String Positions Only After
+    ...    1    81    my search string
+
+Exception Test Get String Positions Only Before
+    Run Keyword And Expect Error    ${Y_AXIS_EXCEEDED_EXPECTED_ERROR}    Get String Positions Only Before
+    ...    25    1    my search string
+    Run Keyword And Expect Error    ${X_AXIS_EXCEEDED_EXPECTED_ERROR}    Get String Positions Only Before
+    ...    1    81    my search string
+
 Test Wait Until String
     Wait Until String    ${WELCOME_TITLE}    timeout=4
 
@@ -291,6 +303,22 @@ Test Get String Positions Only After Case-Insensitive
 
 Test Get String Positions Only After Without Results
     ${positions}    Get String Positions Only After    9    5    Welcome    ignore_case=True
+    Should Be Empty    ${positions}
+
+Test Get String Positions Only Before
+    ${positions}    Get String Positions Only Before    5    11    name
+    Should Be Equal    ${{ [(2, 55), (4, 56)] }}    ${positions}
+
+Test Get String Positions Only Before As Dict
+    ${positions}    Get String Positions Only Before    5    11    name    As Dict
+    Should Be Equal    ${{ [{'ypos': 2, 'xpos': 55}, {'ypos': 4, 'xpos': 56}] }}    ${positions}
+
+Test Get String Positions Only Before Case-Insensitive
+    ${positions}    Get String Positions Only Before    1    11    Welcome    ignore_case=True
+    Should Be Equal    ${{ [(1, 10)] }}    ${positions}
+
+Test Get String Positions Only Before Without Results
+    ${positions}    Get String Positions Only Before    1    10    Welcome    ignore_case=True
     Should Be Empty    ${positions}
 
 

--- a/utest/Mainframe3270/keywords/test_commands.py
+++ b/utest/Mainframe3270/keywords/test_commands.py
@@ -6,6 +6,7 @@ from robot.api import logger
 
 from Mainframe3270.keywords import CommandKeywords
 from Mainframe3270.py3270 import Emulator
+from Mainframe3270.utils import SearchResultMode
 
 from .utils import create_test_object_for
 
@@ -107,7 +108,7 @@ def test_get_current_position(mocker: MockerFixture, under_test: CommandKeywords
 def test_get_current_position_as_dict(mocker: MockerFixture, under_test: CommandKeywords):
     mocker.patch("Mainframe3270.py3270.Emulator.get_current_position", return_value=(6, 6))
 
-    assert under_test.get_current_position("as DiCt") == {"xpos": 6, "ypos": 6}
+    assert under_test.get_current_position(SearchResultMode.As_Dict) == {"xpos": 6, "ypos": 6}
 
 
 def test_get_current_position_invalid_mode(mocker: MockerFixture, under_test: CommandKeywords):

--- a/utest/Mainframe3270/keywords/test_commands.py
+++ b/utest/Mainframe3270/keywords/test_commands.py
@@ -117,7 +117,10 @@ def test_get_current_position_invalid_mode(mocker: MockerFixture, under_test: Co
 
     assert under_test.get_current_position("this is wrong") == (6, 6)
 
-    logger.warn.assert_called_with('"mode" should be either "as dict" or "as tuple". Returning the result as tuple')
+    logger.warn.assert_called_with(
+        '"mode" should be either "SearchResultMode.As_Dict" or "SearchResultMode.As_Tuple". '
+        "Returning the result as tuple"
+    )
 
 
 def test_move_cursor_to(mocker: MockerFixture, under_test: CommandKeywords):

--- a/utest/Mainframe3270/keywords/test_commands.py
+++ b/utest/Mainframe3270/keywords/test_commands.py
@@ -6,7 +6,7 @@ from robot.api import logger
 
 from Mainframe3270.keywords import CommandKeywords
 from Mainframe3270.py3270 import Emulator
-from Mainframe3270.utils import SearchResultMode
+from Mainframe3270.utils import ResultMode
 
 from .utils import create_test_object_for
 
@@ -108,7 +108,7 @@ def test_get_current_position(mocker: MockerFixture, under_test: CommandKeywords
 def test_get_current_position_as_dict(mocker: MockerFixture, under_test: CommandKeywords):
     mocker.patch("Mainframe3270.py3270.Emulator.get_current_position", return_value=(6, 6))
 
-    assert under_test.get_current_position(SearchResultMode.As_Dict) == {"xpos": 6, "ypos": 6}
+    assert under_test.get_current_position(ResultMode.As_Dict) == {"xpos": 6, "ypos": 6}
 
 
 def test_get_current_position_invalid_mode(mocker: MockerFixture, under_test: CommandKeywords):
@@ -118,8 +118,7 @@ def test_get_current_position_invalid_mode(mocker: MockerFixture, under_test: Co
     assert under_test.get_current_position("this is wrong") == (6, 6)
 
     logger.warn.assert_called_with(
-        '"mode" should be either "SearchResultMode.As_Dict" or "SearchResultMode.As_Tuple". '
-        "Returning the result as tuple"
+        '"mode" should be either "ResultMode.As_Dict" or "ResultMode.As_Tuple". ' "Returning the result as tuple"
     )
 
 

--- a/utest/Mainframe3270/keywords/test_read_write.py
+++ b/utest/Mainframe3270/keywords/test_read_write.py
@@ -100,7 +100,10 @@ def test_get_string_positions_invalid_mode(mocker: MockerFixture, under_test: Re
 
     assert under_test.get_string_positions("abc", "this is wrong") == [(5, 10)]
 
-    logger.warn.assert_called_with('"mode" should be either "as dict" or "as tuple". Returning the result as tuple')
+    logger.warn.assert_called_with(
+        '"mode" should be either "SearchResultMode.As_Dict" or "SearchResultMode.As_Tuple". '
+        "Returning the result as tuple"
+    )
     Emulator.get_string_positions.assert_called_once_with("abc", False)
 
 
@@ -115,86 +118,62 @@ def test_get_string_positions_ignore_case(mocker: MockerFixture, under_test: Rea
 def test_get_string_positions_only_after(mocker: MockerFixture, under_test: ReadWriteKeywords):
     mocker.patch("Mainframe3270.py3270.Emulator.check_limits")
     mocker.patch("Mainframe3270.py3270.Emulator.get_string_positions", return_value=[(1, 1), (5, 7)])
-    mocker.patch("Mainframe3270.keywords.ReadWriteKeywords._prepare_result_positions")
 
-    under_test.get_string_positions_only_after(5, 6, "my string")
+    assert under_test.get_string_positions_only_after(5, 6, "my string") == [(5, 7)]
 
     Emulator.check_limits.assert_called_with(5, 6)
     Emulator.get_string_positions.assert_called_with("my string", False)
-    ReadWriteKeywords._prepare_result_positions.assert_called_with(SearchResultMode.As_Tuple, [(5, 7)])
 
 
 def test_get_string_positions_only_after_as_dict(mocker: MockerFixture, under_test: ReadWriteKeywords):
     mocker.patch("Mainframe3270.py3270.Emulator.check_limits")
     mocker.patch("Mainframe3270.py3270.Emulator.get_string_positions", return_value=[(1, 1), (5, 7)])
-    mocker.patch("Mainframe3270.keywords.ReadWriteKeywords._prepare_result_positions")
 
-    under_test.get_string_positions_only_after(5, 6, "my string", SearchResultMode.As_Dict)
+    assert under_test.get_string_positions_only_after(5, 6, "my string", SearchResultMode.As_Dict) == [
+        {"xpos": 7, "ypos": 5}
+    ]
 
     Emulator.check_limits.assert_called_with(5, 6)
     Emulator.get_string_positions.assert_called_with("my string", False)
-    ReadWriteKeywords._prepare_result_positions.assert_called_with(SearchResultMode.As_Dict, [(5, 7)])
 
 
 def test_get_string_positions_only_after_ignore_case(mocker: MockerFixture, under_test: ReadWriteKeywords):
     mocker.patch("Mainframe3270.py3270.Emulator.check_limits")
     mocker.patch("Mainframe3270.py3270.Emulator.get_string_positions", return_value=[(1, 1), (5, 7)])
-    mocker.patch("Mainframe3270.keywords.ReadWriteKeywords._prepare_result_positions")
 
-    under_test.get_string_positions_only_after(5, 6, "my string", ignore_case=True)
+    assert under_test.get_string_positions_only_after(5, 6, "my string", ignore_case=True) == [(5, 7)]
 
     Emulator.check_limits.assert_called_with(5, 6)
     Emulator.get_string_positions.assert_called_with("my string", True)
-    ReadWriteKeywords._prepare_result_positions.assert_called_with(SearchResultMode.As_Tuple, [(5, 7)])
 
 
 def test_get_string_positions_only_before(mocker: MockerFixture, under_test: ReadWriteKeywords):
     mocker.patch("Mainframe3270.py3270.Emulator.check_limits")
     mocker.patch("Mainframe3270.py3270.Emulator.get_string_positions", return_value=[(1, 1), (5, 7)])
-    mocker.patch("Mainframe3270.keywords.ReadWriteKeywords._prepare_result_positions")
 
-    under_test.get_string_positions_only_before(5, 7, "my string")
+    assert under_test.get_string_positions_only_before(5, 7, "my string") == [(1, 1)]
 
     Emulator.check_limits.assert_called_with(5, 7)
     Emulator.get_string_positions.assert_called_with("my string", False)
-    ReadWriteKeywords._prepare_result_positions.assert_called_with(SearchResultMode.As_Tuple, [(1, 1)])
 
 
 def test_get_string_positions_only_before_as_dict(mocker: MockerFixture, under_test: ReadWriteKeywords):
     mocker.patch("Mainframe3270.py3270.Emulator.check_limits")
     mocker.patch("Mainframe3270.py3270.Emulator.get_string_positions", return_value=[(1, 1), (5, 7)])
-    mocker.patch("Mainframe3270.keywords.ReadWriteKeywords._prepare_result_positions")
 
-    under_test.get_string_positions_only_before(5, 7, "my string", SearchResultMode.As_Dict)
+    assert under_test.get_string_positions_only_before(5, 7, "my string", SearchResultMode.As_Dict) == [
+        {"xpos": 1, "ypos": 1}
+    ]
 
     Emulator.check_limits.assert_called_with(5, 7)
     Emulator.get_string_positions.assert_called_with("my string", False)
-    ReadWriteKeywords._prepare_result_positions.assert_called_with(SearchResultMode.As_Dict, [(1, 1)])
 
 
 def test_get_string_positions_only_before_ignore_case(mocker: MockerFixture, under_test: ReadWriteKeywords):
     mocker.patch("Mainframe3270.py3270.Emulator.check_limits")
     mocker.patch("Mainframe3270.py3270.Emulator.get_string_positions", return_value=[(1, 1), (5, 7)])
-    mocker.patch("Mainframe3270.keywords.ReadWriteKeywords._prepare_result_positions")
 
-    under_test.get_string_positions_only_before(5, 7, "my string", ignore_case=True)
+    assert under_test.get_string_positions_only_before(5, 7, "my string", ignore_case=True) == [(1, 1)]
 
     Emulator.check_limits.assert_called_with(5, 7)
     Emulator.get_string_positions.assert_called_with("my string", True)
-    ReadWriteKeywords._prepare_result_positions.assert_called_with(SearchResultMode.As_Tuple, [(1, 1)])
-
-
-def test__prepare_result_positions(under_test: ReadWriteKeywords):
-    assert under_test._prepare_result_positions(SearchResultMode.As_Tuple, [(5, 5)]) == [(5, 5)]
-
-
-def test__prepare_result_positions_as_dict(under_test: ReadWriteKeywords):
-    assert under_test._prepare_result_positions(SearchResultMode.As_Dict, [(5, 6)]) == [{"ypos": 5, "xpos": 6}]
-
-
-def test__prepare_result_positions_invalid_mode(mocker: MockerFixture, under_test: ReadWriteKeywords):
-    mocker.patch("robot.api.logger.warn")
-
-    assert under_test._prepare_result_positions("abc", [(5, 10)]) == [(5, 10)]
-
-    logger.warn.assert_called_with('"mode" should be either "as dict" or "as tuple". Returning the result as tuple')

--- a/utest/Mainframe3270/keywords/test_read_write.py
+++ b/utest/Mainframe3270/keywords/test_read_write.py
@@ -2,7 +2,7 @@ import pytest
 from pytest_mock import MockerFixture
 from robot.api import logger
 
-from Mainframe3270.keywords.read_write import ReadWriteKeywords
+from Mainframe3270.keywords.read_write import ReadWriteKeywords, SearchResultMode
 from Mainframe3270.py3270 import Emulator
 
 from .utils import create_test_object_for
@@ -86,7 +86,10 @@ def test_get_string_positions(mocker: MockerFixture, under_test: ReadWriteKeywor
 def test_get_string_positions_as_dict(mocker: MockerFixture, under_test: ReadWriteKeywords):
     mocker.patch("Mainframe3270.py3270.Emulator.get_string_positions", return_value=[(5, 10), (6, 11)])
 
-    assert under_test.get_string_positions("abc", "aS diCt") == [{"ypos": 5, "xpos": 10}, {"ypos": 6, "xpos": 11}]
+    assert under_test.get_string_positions("abc", SearchResultMode.As_Dict) == [
+        {"ypos": 5, "xpos": 10},
+        {"ypos": 6, "xpos": 11},
+    ]
 
     Emulator.get_string_positions.assert_called_once_with("abc", False)
 

--- a/utest/Mainframe3270/keywords/test_read_write.py
+++ b/utest/Mainframe3270/keywords/test_read_write.py
@@ -2,7 +2,7 @@ import pytest
 from pytest_mock import MockerFixture
 from robot.api import logger
 
-from Mainframe3270.keywords.read_write import ReadWriteKeywords, SearchResultMode
+from Mainframe3270.keywords.read_write import ReadWriteKeywords, ResultMode
 from Mainframe3270.py3270 import Emulator
 
 from .utils import create_test_object_for
@@ -86,7 +86,7 @@ def test_get_string_positions(mocker: MockerFixture, under_test: ReadWriteKeywor
 def test_get_string_positions_as_dict(mocker: MockerFixture, under_test: ReadWriteKeywords):
     mocker.patch("Mainframe3270.py3270.Emulator.get_string_positions", return_value=[(5, 10), (6, 11)])
 
-    assert under_test.get_string_positions("abc", SearchResultMode.As_Dict) == [
+    assert under_test.get_string_positions("abc", ResultMode.As_Dict) == [
         {"ypos": 5, "xpos": 10},
         {"ypos": 6, "xpos": 11},
     ]
@@ -101,8 +101,7 @@ def test_get_string_positions_invalid_mode(mocker: MockerFixture, under_test: Re
     assert under_test.get_string_positions("abc", "this is wrong") == [(5, 10)]
 
     logger.warn.assert_called_with(
-        '"mode" should be either "SearchResultMode.As_Dict" or "SearchResultMode.As_Tuple". '
-        "Returning the result as tuple"
+        '"mode" should be either "ResultMode.As_Dict" or "ResultMode.As_Tuple". ' "Returning the result as tuple"
     )
     Emulator.get_string_positions.assert_called_once_with("abc", False)
 
@@ -129,9 +128,7 @@ def test_get_string_positions_only_after_as_dict(mocker: MockerFixture, under_te
     mocker.patch("Mainframe3270.py3270.Emulator.check_limits")
     mocker.patch("Mainframe3270.py3270.Emulator.get_string_positions", return_value=[(1, 1), (5, 7)])
 
-    assert under_test.get_string_positions_only_after(5, 6, "my string", SearchResultMode.As_Dict) == [
-        {"xpos": 7, "ypos": 5}
-    ]
+    assert under_test.get_string_positions_only_after(5, 6, "my string", ResultMode.As_Dict) == [{"xpos": 7, "ypos": 5}]
 
     Emulator.check_limits.assert_called_with(5, 6)
     Emulator.get_string_positions.assert_called_with("my string", False)
@@ -161,7 +158,7 @@ def test_get_string_positions_only_before_as_dict(mocker: MockerFixture, under_t
     mocker.patch("Mainframe3270.py3270.Emulator.check_limits")
     mocker.patch("Mainframe3270.py3270.Emulator.get_string_positions", return_value=[(1, 1), (5, 7)])
 
-    assert under_test.get_string_positions_only_before(5, 7, "my string", SearchResultMode.As_Dict) == [
+    assert under_test.get_string_positions_only_before(5, 7, "my string", ResultMode.As_Dict) == [
         {"xpos": 1, "ypos": 1}
     ]
 

--- a/utest/Mainframe3270/keywords/test_read_write.py
+++ b/utest/Mainframe3270/keywords/test_read_write.py
@@ -110,3 +110,91 @@ def test_get_string_positions_ignore_case(mocker: MockerFixture, under_test: Rea
     assert under_test.get_string_positions("abc", ignore_case=True) == [(5, 10)]
 
     Emulator.get_string_positions.assert_called_once_with("abc", True)
+
+
+def test_get_string_positions_only_after(mocker: MockerFixture, under_test: ReadWriteKeywords):
+    mocker.patch("Mainframe3270.py3270.Emulator.check_limits")
+    mocker.patch("Mainframe3270.py3270.Emulator.get_string_positions", return_value=[(1, 1), (5, 7)])
+    mocker.patch("Mainframe3270.keywords.ReadWriteKeywords._prepare_result_positions")
+
+    under_test.get_string_positions_only_after(5, 6, "my string")
+
+    Emulator.check_limits.assert_called_with(5, 6)
+    Emulator.get_string_positions.assert_called_with("my string", False)
+    ReadWriteKeywords._prepare_result_positions.assert_called_with(SearchResultMode.As_Tuple, [(5, 7)])
+
+
+def test_get_string_positions_only_after_as_dict(mocker: MockerFixture, under_test: ReadWriteKeywords):
+    mocker.patch("Mainframe3270.py3270.Emulator.check_limits")
+    mocker.patch("Mainframe3270.py3270.Emulator.get_string_positions", return_value=[(1, 1), (5, 7)])
+    mocker.patch("Mainframe3270.keywords.ReadWriteKeywords._prepare_result_positions")
+
+    under_test.get_string_positions_only_after(5, 6, "my string", SearchResultMode.As_Dict)
+
+    Emulator.check_limits.assert_called_with(5, 6)
+    Emulator.get_string_positions.assert_called_with("my string", False)
+    ReadWriteKeywords._prepare_result_positions.assert_called_with(SearchResultMode.As_Dict, [(5, 7)])
+
+
+def test_get_string_positions_only_after_ignore_case(mocker: MockerFixture, under_test: ReadWriteKeywords):
+    mocker.patch("Mainframe3270.py3270.Emulator.check_limits")
+    mocker.patch("Mainframe3270.py3270.Emulator.get_string_positions", return_value=[(1, 1), (5, 7)])
+    mocker.patch("Mainframe3270.keywords.ReadWriteKeywords._prepare_result_positions")
+
+    under_test.get_string_positions_only_after(5, 6, "my string", ignore_case=True)
+
+    Emulator.check_limits.assert_called_with(5, 6)
+    Emulator.get_string_positions.assert_called_with("my string", True)
+    ReadWriteKeywords._prepare_result_positions.assert_called_with(SearchResultMode.As_Tuple, [(5, 7)])
+
+
+def test_get_string_positions_only_before(mocker: MockerFixture, under_test: ReadWriteKeywords):
+    mocker.patch("Mainframe3270.py3270.Emulator.check_limits")
+    mocker.patch("Mainframe3270.py3270.Emulator.get_string_positions", return_value=[(1, 1), (5, 7)])
+    mocker.patch("Mainframe3270.keywords.ReadWriteKeywords._prepare_result_positions")
+
+    under_test.get_string_positions_only_before(5, 7, "my string")
+
+    Emulator.check_limits.assert_called_with(5, 7)
+    Emulator.get_string_positions.assert_called_with("my string", False)
+    ReadWriteKeywords._prepare_result_positions.assert_called_with(SearchResultMode.As_Tuple, [(1, 1)])
+
+
+def test_get_string_positions_only_before_as_dict(mocker: MockerFixture, under_test: ReadWriteKeywords):
+    mocker.patch("Mainframe3270.py3270.Emulator.check_limits")
+    mocker.patch("Mainframe3270.py3270.Emulator.get_string_positions", return_value=[(1, 1), (5, 7)])
+    mocker.patch("Mainframe3270.keywords.ReadWriteKeywords._prepare_result_positions")
+
+    under_test.get_string_positions_only_before(5, 7, "my string", SearchResultMode.As_Dict)
+
+    Emulator.check_limits.assert_called_with(5, 7)
+    Emulator.get_string_positions.assert_called_with("my string", False)
+    ReadWriteKeywords._prepare_result_positions.assert_called_with(SearchResultMode.As_Dict, [(1, 1)])
+
+
+def test_get_string_positions_only_before_ignore_case(mocker: MockerFixture, under_test: ReadWriteKeywords):
+    mocker.patch("Mainframe3270.py3270.Emulator.check_limits")
+    mocker.patch("Mainframe3270.py3270.Emulator.get_string_positions", return_value=[(1, 1), (5, 7)])
+    mocker.patch("Mainframe3270.keywords.ReadWriteKeywords._prepare_result_positions")
+
+    under_test.get_string_positions_only_before(5, 7, "my string", ignore_case=True)
+
+    Emulator.check_limits.assert_called_with(5, 7)
+    Emulator.get_string_positions.assert_called_with("my string", True)
+    ReadWriteKeywords._prepare_result_positions.assert_called_with(SearchResultMode.As_Tuple, [(1, 1)])
+
+
+def test__prepare_result_positions(under_test: ReadWriteKeywords):
+    assert under_test._prepare_result_positions(SearchResultMode.As_Tuple, [(5, 5)]) == [(5, 5)]
+
+
+def test__prepare_result_positions_as_dict(under_test: ReadWriteKeywords):
+    assert under_test._prepare_result_positions(SearchResultMode.As_Dict, [(5, 6)]) == [{"ypos": 5, "xpos": 6}]
+
+
+def test__prepare_result_positions_invalid_mode(mocker: MockerFixture, under_test: ReadWriteKeywords):
+    mocker.patch("robot.api.logger.warn")
+
+    assert under_test._prepare_result_positions("abc", [(5, 10)]) == [(5, 10)]
+
+    logger.warn.assert_called_with('"mode" should be either "as dict" or "as tuple". Returning the result as tuple')

--- a/utest/Mainframe3270/test_utils.py
+++ b/utest/Mainframe3270/test_utils.py
@@ -1,6 +1,15 @@
 from datetime import timedelta
 
-from Mainframe3270.utils import convert_timeout, coordinates_to_dict
+from pytest_mock import MockerFixture
+from robot.api import logger
+
+from Mainframe3270.utils import (
+    SearchResultMode,
+    convert_timeout,
+    coordinates_to_dict,
+    prepare_position_as,
+    prepare_positions_as,
+)
 
 
 def test_convert_timeout_with_timedelta():
@@ -12,6 +21,33 @@ def test_convert_timeout_with_timedelta():
 def test_convert_timeout_with_timestring():
     timeout = convert_timeout("1 minute")
     assert timeout == 60.0
+
+
+def test_prepare_position_as():
+    assert prepare_position_as((5, 5), SearchResultMode.As_Tuple) == (5, 5)
+
+
+def test_prepare_position_as_dict():
+    assert prepare_position_as((5, 6), SearchResultMode.As_Dict) == {"ypos": 5, "xpos": 6}
+
+
+def test_prepare_positions_as():
+    assert prepare_positions_as([(5, 5)], SearchResultMode.As_Tuple) == [(5, 5)]
+
+
+def test_prepare_positions_as_dict():
+    assert prepare_positions_as([(5, 6)], SearchResultMode.As_Dict) == [{"ypos": 5, "xpos": 6}]
+
+
+def test_prepare_positions_as_invalid_mode(mocker: MockerFixture):
+    mocker.patch("robot.api.logger.warn")
+
+    assert prepare_positions_as([(5, 10)], "abc") == [(5, 10)]
+
+    logger.warn.assert_called_with(
+        '"mode" should be either "SearchResultMode.As_Dict" or "SearchResultMode.As_Tuple". '
+        "Returning the result as tuple"
+    )
 
 
 def test_coordinates_to_dict():

--- a/utest/Mainframe3270/test_utils.py
+++ b/utest/Mainframe3270/test_utils.py
@@ -4,7 +4,7 @@ from pytest_mock import MockerFixture
 from robot.api import logger
 
 from Mainframe3270.utils import (
-    SearchResultMode,
+    ResultMode,
     convert_timeout,
     coordinates_to_dict,
     prepare_position_as,
@@ -24,19 +24,19 @@ def test_convert_timeout_with_timestring():
 
 
 def test_prepare_position_as():
-    assert prepare_position_as((5, 5), SearchResultMode.As_Tuple) == (5, 5)
+    assert prepare_position_as((5, 5), ResultMode.As_Tuple) == (5, 5)
 
 
 def test_prepare_position_as_dict():
-    assert prepare_position_as((5, 6), SearchResultMode.As_Dict) == {"ypos": 5, "xpos": 6}
+    assert prepare_position_as((5, 6), ResultMode.As_Dict) == {"ypos": 5, "xpos": 6}
 
 
 def test_prepare_positions_as():
-    assert prepare_positions_as([(5, 5)], SearchResultMode.As_Tuple) == [(5, 5)]
+    assert prepare_positions_as([(5, 5)], ResultMode.As_Tuple) == [(5, 5)]
 
 
 def test_prepare_positions_as_dict():
-    assert prepare_positions_as([(5, 6)], SearchResultMode.As_Dict) == [{"ypos": 5, "xpos": 6}]
+    assert prepare_positions_as([(5, 6)], ResultMode.As_Dict) == [{"ypos": 5, "xpos": 6}]
 
 
 def test_prepare_positions_as_invalid_mode(mocker: MockerFixture):
@@ -45,8 +45,7 @@ def test_prepare_positions_as_invalid_mode(mocker: MockerFixture):
     assert prepare_positions_as([(5, 10)], "abc") == [(5, 10)]
 
     logger.warn.assert_called_with(
-        '"mode" should be either "SearchResultMode.As_Dict" or "SearchResultMode.As_Tuple". '
-        "Returning the result as tuple"
+        '"mode" should be either "ResultMode.As_Dict" or "ResultMode.As_Tuple". ' "Returning the result as tuple"
     )
 
 

--- a/utest/py3270/test_emulator.py
+++ b/utest/py3270/test_emulator.py
@@ -211,8 +211,8 @@ def test_string_get(mocker: MockerFixture):
 
 
 @pytest.mark.usefixtures("mock_windows")
-def test_string_get_calls__check_limits(mocker: MockerFixture):
-    mocker.patch("Mainframe3270.py3270.Emulator._check_limits")
+def test_string_get_calls_check_limits(mocker: MockerFixture):
+    mocker.patch("Mainframe3270.py3270.Emulator.check_limits")
     mocker.patch("Mainframe3270.py3270.wc3270App.write")
     mocker.patch(
         "Mainframe3270.py3270.wc3270App.readline",
@@ -226,7 +226,7 @@ def test_string_get_calls__check_limits(mocker: MockerFixture):
 
     under_test.string_get(1, 10, 48)
 
-    Emulator._check_limits.assert_called_with(1, 10)
+    Emulator.check_limits.assert_called_with(1, 10)
 
 
 @pytest.mark.usefixtures("mock_windows")
@@ -309,7 +309,7 @@ def test_read_all_screen_with_different_model_dimensions(mocker: MockerFixture, 
 def test_check_limits():
     under_test = Emulator()
 
-    under_test._check_limits(24, 80)
+    under_test.check_limits(24, 80)
 
 
 @pytest.mark.usefixtures("mock_windows")
@@ -330,7 +330,7 @@ def test_check_limits_raises_Exception(model, ypos, xpos, expected_error):
     under_test = Emulator(model=model)
 
     with pytest.raises(Exception, match=expected_error):
-        under_test._check_limits(ypos, xpos)
+        under_test.check_limits(ypos, xpos)
 
 
 def test_get_current_cursor_position(mocker: MockerFixture):


### PR DESCRIPTION
Closes #117 

@Harm10 , please have a look at the acceptance tests in atest/mainframe.robot. I have implemented the keywords in a way that the specified ypos / xpos in Only Before and Only After are themselves not included. I hope that this is the intended behavior.