### PR TITLE
Fix Replacement of German Umlauts

### DIFF
--- a/Mainframe3270/py3270.py
+++ b/Mainframe3270/py3270.py
@@ -530,8 +530,6 @@ class Emulator(object):
             # Stage 3: Replace Unicode box drawing range
             full_text = re.sub(r"[\u2500-\u257F]", "-", full_text)
 
-            # Stage 4: Replace any non-ASCII characters that might be box drawing
-            full_text = re.sub(r"[^\x20-\x7E]", "-", full_text, flags=re.UNICODE)
         return full_text
 
     def delete_field(self):


### PR DESCRIPTION
With PR https://github.com/MarketSquare/Robot-Framework-Mainframe-3270-Library/pull/141 I added a replacement stategy for replacing the Unicode characters to handle the different positions in the host environment.
In our recent test we found out, that the regex that is used to deal with the issue is too eager. It also replaces common German Umlaut characters such as "Ä". Therefore I removed the "Stage 4" to be able to use them.