### PR TITLE
Add Feature: Browser selection

### DIFF
--- a/Mainframe3270/keywords/screenshot.py
+++ b/Mainframe3270/keywords/screenshot.py
@@ -1,9 +1,9 @@
 import os
 import time
+from html2image import Html2Image
 from robot.api import logger
 from robot.api.deco import keyword
 from Mainframe3270.librarycomponent import LibraryComponent
-
 
 
 class ScreenshotKeywords(LibraryComponent):
@@ -25,7 +25,12 @@ class ScreenshotKeywords(LibraryComponent):
 
     @keyword("Take Screenshot")
     def take_screenshot(
-            self, height: int = 400, width: int = 600, filename_prefix: str = "screenshot", img: bool = False, browser: str = "chrome"
+        self,
+        height: int = 400,
+        width: int = 600,
+        filename_prefix: str = "screenshot",
+        img: bool = False,
+        browser: str = "chrome",
     ) -> str:
         """Generate a screenshot of the IBM 3270 Mainframe in a html or png format. The
         default folder is the log folder of RobotFramework, if you want change see the `Set Screenshot Folder`.
@@ -37,7 +42,7 @@ class ScreenshotKeywords(LibraryComponent):
         module this option only works if chrome is installed in your system.
 
         The file name prefix can be set, the default is "screenshot".
-        
+
         The Html2Image compatible browser that should be used for creating a png screenshot can be selected with the `browser` parameter, the default is "chrome".
 
         The file path is returned.
@@ -50,22 +55,17 @@ class ScreenshotKeywords(LibraryComponent):
             | Take Screenshot | height=500 | width=700 |
             | Take Screenshot | filename_prefix=MyScreenshot |
         """
-        try:
-            from html2image import Html2Image
-
-            hti = Html2Image(size=(600, 500), browser=browser)
-        except Exception as exception:
-            logger.info("\n" + str(exception), also_console=True)
-            logger.info(f"Browser {browser} not found. Take Screenshot will work only in html format.", also_console=True)
         filename_suffix = str(round(time.time() * 1000))
         filepath = os.path.join(self.img_folder, f"{filename_prefix}_{filename_suffix}.html")
         self.mf.save_screen(filepath)
         if img:
             try:
-                hti.output_path = self.img_folder
+                hti = Html2Image(size=(600, 500), browser=browser)
             except Exception as exception:
                 logger.info("\n" + str(exception), also_console=True)
-                raise EnvironmentError("Chrome not found, please use argument ${img}=False")
+                raise EnvironmentError(f"Browser {browser} not found, please use argument ${img}=False")
+ 
+            hti.output_path = self.img_folder
             img_name = f"{filename_prefix}_{filename_suffix}.png"
             img_path = os.path.join(self.img_folder, img_name)
             hti.screenshot(html_file=filepath, save_as=img_name)

--- a/atest/mainframe.robot
+++ b/atest/mainframe.robot
@@ -180,16 +180,10 @@ Test Take Screenshot
 
 Test Take Screenshot With Edge Browser
     [Tags]    no-ci
-    ${system}=    Evaluate    platform.system()    platform
-    IF    '${system}' != 'Windows'
-        Log    Not running on Windows, skipping test
-        Pass Execution
-    ELSE
-        ${html_file}    Take Screenshot  browser=edge
-        File Should Exist    ${html_file}
-        ${png_file}    Take Screenshot    img=${True}  browser=edge
-        File Should Exist    ${png_file}
-    END
+    ${html_file}    Take Screenshot    browser=edge
+    File Should Exist    ${html_file}
+    ${png_file}    Take Screenshot    img=${True}    browser=edge
+    File Should Exist    ${png_file}
 
 Test Write Bare
     Move Cursor To    5    25
@@ -328,7 +322,7 @@ Test Get String Positions Only Before Without Results
 
 *** Keywords ***
 Suite Mainframe Setup
-    Open Connection    ${HOST}  port=3270
+    Open Connection    ${HOST}
     Create Directory    ${FOLDER}
     Empty Directory    ${FOLDER}
     Set Screenshot Folder    ${FOLDER}


### PR DESCRIPTION
When running some Mainframe Tests on a default Windows installation (without Chrome) I found out, that the `Take Screenshot  img=True` keyword failed with "Chrome not installed". After checking the underlying Html2Image library, I saw, that it is possible to use different browsers too.

This PR add another parameter `browser` to the `Take Screenshot` keyword to be able to select a supported browser. It defaults to `chrome` to be backwards compatible.