### PR TITLE
Add replace_unicode to Get String Position keywords

### DIFF
--- a/Mainframe3270/keywords/read_write.py
+++ b/Mainframe3270/keywords/read_write.py
@@ -49,7 +49,7 @@ class ReadWriteKeywords(LibraryComponent):
         return self.mf.read_all_screen(replace_unicode)
 
     @keyword("Get String Positions")
-    def get_string_positions(self, string: str, mode: ResultMode = ResultMode.As_Tuple, ignore_case: bool = False):
+    def get_string_positions(self, string: str, mode: ResultMode = ResultMode.As_Tuple, ignore_case: bool = False, replace_unicode: bool = True):
         """Returns a list of tuples of ypos and xpos for the position where the `string` was found,
         or an empty list if it was not found.
 
@@ -58,11 +58,16 @@ class ReadWriteKeywords(LibraryComponent):
 
         If `ignore_case` is set to `True`, then the search is done case-insensitively.
 
+        NEW in version 4.4: The `replace_unicode` argument was added to control whether Unicode values should be
+        replaced with their corresponding characters. This is useful if you need to get the string positions for strings with unicode symbols like umlauts.
+
+
         Example:
-            | ${positions} | Get String Positions | Abc |         | # Returns a list like [(1, 8)] |
-            | ${positions} | Get String Positions | Abc | As Dict | # Returns a list like [{"ypos": 1, "xpos": 8}] |
+            | ${positions} | Get String Positions | Abc |         |                       | # Returns a list like [(1, 8)] |
+            | ${positions} | Get String Positions | Abc | As Dict |                       | # Returns a list like [{"ypos": 1, "xpos": 8}] |
+            | ${positions} | Get String Positions | Üab | As Dict | replace_unicode=False | # Returns a list like [{"ypos": 1, "xpos": 8}] |
         """
-        positions = self.mf.get_string_positions(string, ignore_case)
+        positions = self.mf.get_string_positions(string, ignore_case, replace_unicode)
         return prepare_positions_as(positions, mode)
 
     @keyword("Get String Positions Only After")
@@ -73,6 +78,7 @@ class ReadWriteKeywords(LibraryComponent):
         string: str,
         mode: ResultMode = ResultMode.As_Tuple,
         ignore_case: bool = False,
+        replace_unicode: bool = True
     ):
         """Returns a list of tuples of ypos and xpos for the position where the `string` was found,
         but only after the specified ypos/xpos coordinates. If it is not found an empty list is returned.
@@ -82,12 +88,16 @@ class ReadWriteKeywords(LibraryComponent):
 
         If `ignore_case` is set to `True`, then the search is done case-insensitively.
 
+        NEW in version 4.4: The `replace_unicode` argument was added to control whether Unicode values should be
+        replaced with their corresponding characters. This is useful if you need to get the string positions for strings with unicode symbols like umlauts.
+
         Example:
-            | ${positions} | Get String Positions Only After | 5 | 4 | Abc |         | # Returns a list like [(5, 5)] |
-            | ${positions} | Get String Positions Only After | 5 | 4 | Abc | As Dict | # Returns a list like [{"ypos": 5, "xpos": 5}] |
+            | ${positions} | Get String Positions Only After | 5 | 4 | Abc |         |                       | # Returns a list like [(5, 5)] |
+            | ${positions} | Get String Positions Only After | 5 | 4 | Abc | As Dict |                       | # Returns a list like [{"ypos": 5, "xpos": 5}] |
+            | ${positions} | Get String Positions Only After | 5 | 4 | Übc | As Dict | replace_unicode=False | # Returns a list like [{"ypos": 5, "xpos": 5}] |
         """
         self.mf.check_limits(ypos, xpos)
-        positions = self.mf.get_string_positions(string, ignore_case)
+        positions = self.mf.get_string_positions(string, ignore_case, replace_unicode)
         filtered_positions = [position for position in positions if position > (ypos, xpos)]
         return prepare_positions_as(filtered_positions, mode)
 
@@ -99,6 +109,7 @@ class ReadWriteKeywords(LibraryComponent):
         string: str,
         mode: ResultMode = ResultMode.As_Tuple,
         ignore_case: bool = False,
+        replace_unicode: bool = True
     ):
         """Returns a list of tuples of ypos and xpos for the position where the `string` was found,
         but only before the specified ypos/xpos coordinates. If it is not found an empty list is returned.
@@ -108,12 +119,16 @@ class ReadWriteKeywords(LibraryComponent):
 
         If `ignore_case` is set to `True`, then the search is done case-insensitively.
 
+        NEW in version 4.4: The `replace_unicode` argument was added to control whether Unicode values should be
+        replaced with their corresponding characters. This is useful if you need to get the string positions for strings with unicode symbols like umlauts.
+
         Example:
-            | ${positions} | Get String Positions Only Before | 11 | 20 | Abc |         | # Returns a list like [(11, 19)] |
-            | ${positions} | Get String Positions Only Before | 11 | 20 | Abc | As Dict | # Returns a list like [{"ypos": 11, "xpos": 19}] |
+            | ${positions} | Get String Positions Only Before | 11 | 20 | Abc |         |                       | # Returns a list like [(11, 19)] |
+            | ${positions} | Get String Positions Only Before | 11 | 20 | Abc | As Dict |                       | # Returns a list like [{"ypos": 11, "xpos": 19}] |
+            | ${positions} | Get String Positions Only Before | 11 | 20 | Übc | As Dict | replace_unicode=False | # Returns a list like [{"ypos": 11, "xpos": 19}] |
         """
         self.mf.check_limits(ypos, xpos)
-        positions = self.mf.get_string_positions(string, ignore_case)
+        positions = self.mf.get_string_positions(string, ignore_case, replace_unicode)
         filtered_positions = [position for position in positions if position < (ypos, xpos)]
         return prepare_positions_as(filtered_positions, mode)
 

--- a/Mainframe3270/py3270.py
+++ b/Mainframe3270/py3270.py
@@ -490,10 +490,10 @@ class Emulator(object):
                 return True
         return False
 
-    def get_string_positions(self, string, ignore_case=False):
+    def get_string_positions(self, string, ignore_case=False, replace_unicode=True):
         """Returns a list of tuples of ypos and xpos for the position where the `string` was found,
         or an empty list if it was not found."""
-        screen_content = self.read_all_screen()
+        screen_content = self.read_all_screen(replace_unicode=replace_unicode)
         indices_object = re.finditer(re.escape(string), screen_content, flags=0 if not ignore_case else re.IGNORECASE)
         indices = [index.start() for index in indices_object]
         # ypos and xpos should be returned 1-based

--- a/utest/Mainframe3270/keywords/test_read_write.py
+++ b/utest/Mainframe3270/keywords/test_read_write.py
@@ -107,7 +107,7 @@ def test_get_string_positions(mocker: MockerFixture, under_test: ReadWriteKeywor
 
     assert under_test.get_string_positions("abc") == [(5, 10)]
 
-    Emulator.get_string_positions.assert_called_once_with("abc", False)
+    Emulator.get_string_positions.assert_called_once_with("abc", False, True)
 
 
 def test_get_string_positions_as_dict(mocker: MockerFixture, under_test: ReadWriteKeywords):
@@ -118,7 +118,7 @@ def test_get_string_positions_as_dict(mocker: MockerFixture, under_test: ReadWri
         {"ypos": 6, "xpos": 11},
     ]
 
-    Emulator.get_string_positions.assert_called_once_with("abc", False)
+    Emulator.get_string_positions.assert_called_once_with("abc", False, True)
 
 
 def test_get_string_positions_invalid_mode(mocker: MockerFixture, under_test: ReadWriteKeywords):
@@ -130,7 +130,7 @@ def test_get_string_positions_invalid_mode(mocker: MockerFixture, under_test: Re
     logger.warn.assert_called_with(
         '"mode" should be either "ResultMode.As_Dict" or "ResultMode.As_Tuple". ' "Returning the result as tuple"
     )
-    Emulator.get_string_positions.assert_called_once_with("abc", False)
+    Emulator.get_string_positions.assert_called_once_with("abc", False, True)
 
 
 def test_get_string_positions_ignore_case(mocker: MockerFixture, under_test: ReadWriteKeywords):
@@ -138,7 +138,7 @@ def test_get_string_positions_ignore_case(mocker: MockerFixture, under_test: Rea
 
     assert under_test.get_string_positions("abc", ignore_case=True) == [(5, 10)]
 
-    Emulator.get_string_positions.assert_called_once_with("abc", True)
+    Emulator.get_string_positions.assert_called_once_with("abc", True, True)
 
 
 def test_get_string_positions_only_after(mocker: MockerFixture, under_test: ReadWriteKeywords):
@@ -148,7 +148,7 @@ def test_get_string_positions_only_after(mocker: MockerFixture, under_test: Read
     assert under_test.get_string_positions_only_after(5, 6, "my string") == [(5, 7)]
 
     Emulator.check_limits.assert_called_with(5, 6)
-    Emulator.get_string_positions.assert_called_with("my string", False)
+    Emulator.get_string_positions.assert_called_with("my string", False, True)
 
 
 def test_get_string_positions_only_after_as_dict(mocker: MockerFixture, under_test: ReadWriteKeywords):
@@ -158,7 +158,7 @@ def test_get_string_positions_only_after_as_dict(mocker: MockerFixture, under_te
     assert under_test.get_string_positions_only_after(5, 6, "my string", ResultMode.As_Dict) == [{"xpos": 7, "ypos": 5}]
 
     Emulator.check_limits.assert_called_with(5, 6)
-    Emulator.get_string_positions.assert_called_with("my string", False)
+    Emulator.get_string_positions.assert_called_with("my string", False, True)
 
 
 def test_get_string_positions_only_after_ignore_case(mocker: MockerFixture, under_test: ReadWriteKeywords):
@@ -168,7 +168,7 @@ def test_get_string_positions_only_after_ignore_case(mocker: MockerFixture, unde
     assert under_test.get_string_positions_only_after(5, 6, "my string", ignore_case=True) == [(5, 7)]
 
     Emulator.check_limits.assert_called_with(5, 6)
-    Emulator.get_string_positions.assert_called_with("my string", True)
+    Emulator.get_string_positions.assert_called_with("my string", True, True)
 
 
 def test_get_string_positions_only_before(mocker: MockerFixture, under_test: ReadWriteKeywords):
@@ -178,7 +178,7 @@ def test_get_string_positions_only_before(mocker: MockerFixture, under_test: Rea
     assert under_test.get_string_positions_only_before(5, 7, "my string") == [(1, 1)]
 
     Emulator.check_limits.assert_called_with(5, 7)
-    Emulator.get_string_positions.assert_called_with("my string", False)
+    Emulator.get_string_positions.assert_called_with("my string", False, True)
 
 
 def test_get_string_positions_only_before_as_dict(mocker: MockerFixture, under_test: ReadWriteKeywords):
@@ -190,7 +190,7 @@ def test_get_string_positions_only_before_as_dict(mocker: MockerFixture, under_t
     ]
 
     Emulator.check_limits.assert_called_with(5, 7)
-    Emulator.get_string_positions.assert_called_with("my string", False)
+    Emulator.get_string_positions.assert_called_with("my string", False, True)
 
 
 def test_get_string_positions_only_before_ignore_case(mocker: MockerFixture, under_test: ReadWriteKeywords):
@@ -200,4 +200,4 @@ def test_get_string_positions_only_before_ignore_case(mocker: MockerFixture, und
     assert under_test.get_string_positions_only_before(5, 7, "my string", ignore_case=True) == [(1, 1)]
 
     Emulator.check_limits.assert_called_with(5, 7)
-    Emulator.get_string_positions.assert_called_with("my string", True)
+    Emulator.get_string_positions.assert_called_with("my string", True, True)


### PR DESCRIPTION
In https://github.com/MarketSquare/Robot-Framework-Mainframe-3270-Library/pull/147 a new parameter `replace_unicode` was introduced. This PR is a followup that also add this parameter to the `Get String Position` keywords.
This is useful if you need to get the string position of a label that contains a german umlaut like äüö.